### PR TITLE
Add hybrid search support for Weaviate client

### DIFF
--- a/IntelligenceHub.Business/Handlers/ValidationHandler.cs
+++ b/IntelligenceHub.Business/Handlers/ValidationHandler.cs
@@ -352,6 +352,7 @@ namespace IntelligenceHub.Business.Handlers
 
             if (!string.IsNullOrEmpty(index.ScoringProfile?.Name))
             {
+                if (index.RagHost == RagServiceHost.Weaviate) return "Scoring profiles are not supported when using the Weaviate RagHost.";
                 if (string.IsNullOrWhiteSpace(index.ScoringProfile.Name)) return "The ScoringProfile name is required.";
                 if (index.ScoringProfile.Name.Length > 128) return "The ScoringProfile name exceeds the maximum allowed length of 255 characters.";
                 if (index.QueryType.ToString().Length > 255) return "The QueryType exceeds the maximum allowed length of 255 characters.";


### PR DESCRIPTION
## Summary
- support BM25, vector and hybrid queries in WeaviateSearchServiceClient
- warn users if a scoring profile is provided when using Weaviate in ValidationHandler

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8091b528832ea847e2da435a5450