### PR TITLE
Support Weaviate embedding models

### DIFF
--- a/IntelligenceHub.Business/Handlers/ValidationHandler.cs
+++ b/IntelligenceHub.Business/Handlers/ValidationHandler.cs
@@ -346,6 +346,14 @@ namespace IntelligenceHub.Business.Handlers
             if (index.IndexingInterval <= TimeSpan.Zero) return "IndexingInterval must be a positive value.";
             if (index.IndexingInterval >= TimeSpan.FromDays(1)) return "The indexing interval must be less than 1 day.";
             if (!string.IsNullOrWhiteSpace(index.EmbeddingModel) && index.EmbeddingModel.Length > 255) return "The EmbeddingModel exceeds the maximum allowed length of 255 characters.";
+            if (!string.IsNullOrWhiteSpace(index.EmbeddingModel))
+            {
+                var lowerModel = index.EmbeddingModel.ToLower();
+                if (index.RagHost == RagServiceHost.Weaviate && !lowerModel.StartsWith("text2vec"))
+                    return "EmbeddingModel must correspond with the Weaviate RagHost (text2vec-*).";
+                if (index.RagHost == RagServiceHost.Azure && lowerModel.StartsWith("text2vec"))
+                    return "EmbeddingModel beginning with 'text2vec-' is reserved for the Weaviate RagHost.";
+            }
             if (index.MaxRagAttachments < 0) return "MaxRagAttachments must be a non-negative integer greater than 0.";
             if (index.MaxRagAttachments > 20) return "MaxRagAttachments cannot exceed 20.";
             if (index.ChunkOverlap < 0 || index.ChunkOverlap > 1) return "ChunkOverlap must be between 0 and 1 (inclusive).";

--- a/IntelligenceHub.Client/Implementations/WeaviateSearchServiceClient.cs
+++ b/IntelligenceHub.Client/Implementations/WeaviateSearchServiceClient.cs
@@ -94,16 +94,52 @@ namespace IntelligenceHub.Client.Implementations
 
         public async Task<bool> UpsertIndex(IndexMetadata indexDefinition)
         {
+            var model = string.IsNullOrWhiteSpace(indexDefinition.EmbeddingModel)
+                ? DefaultWeaviateEmbeddingModel
+                : indexDefinition.EmbeddingModel;
+
             var schema = new
             {
                 @class = indexDefinition.Name,
-                vectorizer = "none",
+                vectorizer = model,
                 properties = new[]
                 {
-                    new { name = "title", dataType = new[]{"text"} },
-                    new { name = "chunk", dataType = new[]{"text"} },
-                    new { name = "topic", dataType = new[]{"text"} },
-                    new { name = "keywords", dataType = new[]{"text"} },
+                    new
+                    {
+                        name = "title",
+                        dataType = new[]{"text"},
+                        moduleConfig = new Dictionary<string, object>
+                        {
+                            [model] = new { skip = !(indexDefinition.GenerateTitleVector ?? false) }
+                        }
+                    },
+                    new
+                    {
+                        name = "chunk",
+                        dataType = new[]{"text"},
+                        moduleConfig = new Dictionary<string, object>
+                        {
+                            [model] = new { skip = !(indexDefinition.GenerateContentVector ?? false) }
+                        }
+                    },
+                    new
+                    {
+                        name = "topic",
+                        dataType = new[]{"text"},
+                        moduleConfig = new Dictionary<string, object>
+                        {
+                            [model] = new { skip = !(indexDefinition.GenerateTopicVector ?? false) }
+                        }
+                    },
+                    new
+                    {
+                        name = "keywords",
+                        dataType = new[]{"text"},
+                        moduleConfig = new Dictionary<string, object>
+                        {
+                            [model] = new { skip = !(indexDefinition.GenerateKeywordVector ?? false) }
+                        }
+                    },
                     new { name = "source", dataType = new[]{"text"} },
                     new { name = "created", dataType = new[]{"date"} },
                     new { name = "modified", dataType = new[]{"date"} }

--- a/IntelligenceHub.Common/GlobalVariables.cs
+++ b/IntelligenceHub.Common/GlobalVariables.cs
@@ -245,6 +245,11 @@
         public const string DefaultEmbeddingModel = "text-embedding-3-large";
 
         /// <summary>
+        /// The default embedding model used when indexing with Weaviate.
+        /// </summary>
+        public const string DefaultWeaviateEmbeddingModel = "text2vec-openai";
+
+        /// <summary>
         /// The default model for image generation.
         /// </summary>
         public const string DefaultImageGenModel = "dall-e-3";


### PR DESCRIPTION
## Summary
- add default Weaviate embedding model constant
- allow WeaviateSearchServiceClient to use Weaviate vectorizers when creating classes
- validate embedding model corresponds with selected RagHost

## Testing
- `dotnet test --no-restore --verbosity quiet` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6f56b628832e8f6b18207a144fe2