### PR TITLE
Refactor RAG client APIs

### DIFF
--- a/IntelligenceHub.Client/Implementations/WeaviateSearchServiceClient.cs
+++ b/IntelligenceHub.Client/Implementations/WeaviateSearchServiceClient.cs
@@ -92,7 +92,7 @@ namespace IntelligenceHub.Client.Implementations
             return SearchModelFactory.SearchResults(values: results, totalCount: results.Count, facets: null, coverage: null, rawResponse: null);
         }
 
-        public async Task<bool> UpsertIndex(IndexMetadata indexDefinition)
+        public async Task<bool> CreateIndex(IndexMetadata indexDefinition)
         {
             var model = string.IsNullOrWhiteSpace(indexDefinition.EmbeddingModel)
                 ? DefaultWeaviateEmbeddingModel
@@ -157,11 +157,6 @@ namespace IntelligenceHub.Client.Implementations
             return res.IsSuccessStatusCode;
         }
 
-        public Task<bool> UpsertIndexer(IndexMetadata index) => Task.FromResult(true);
-        public Task<bool> RunIndexer(string indexName) => Task.FromResult(true);
-        public Task<bool> DeleteIndexer(string indexName) => Task.FromResult(true);
-        public Task<bool> CreateDatasource(string databaseName) => Task.FromResult(true);
-        public Task<bool> DeleteDatasource(string indexName) => Task.FromResult(true);
 
         public async Task<List<IndexDocument>> GetAllDocuments(string indexName)
         {

--- a/IntelligenceHub.Client/Interfaces/IAISearchServiceClient.cs
+++ b/IntelligenceHub.Client/Interfaces/IAISearchServiceClient.cs
@@ -4,7 +4,7 @@ using IntelligenceHub.API.DTOs.RAG;
 namespace IntelligenceHub.Client.Interfaces
 {
     /// <summary>
-    /// A Azure AI Search Services client oriented around RAG construction and consumption.
+    /// A search service client oriented around RAG construction and consumption.
     /// </summary>
     public interface IAISearchServiceClient
     {
@@ -14,55 +14,33 @@ namespace IntelligenceHub.Client.Interfaces
         /// <param name="index">The definition of the RAG index.</param>
         /// <param name="query">The query to search against the RAG index.</param>
         /// <returns>Returns the search results retrieved from the RAG index.</returns>
-        public Task<SearchResults<IndexDefinition>> SearchIndex(IndexMetadata index, string query);
+        Task<SearchResults<IndexDefinition>> SearchIndex(IndexMetadata index, string query);
 
         /// <summary>
-        /// Creates or updates a RAG index.
+        /// Creates a new RAG index.
         /// </summary>
         /// <param name="indexDefinition">The definition of the index.</param>
         /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> UpsertIndex(IndexMetadata indexDefinition);
+        Task<bool> CreateIndex(IndexMetadata indexDefinition);
 
         /// <summary>
-        /// Deletes a RAG index.
+        /// Deletes a RAG index and any associated resources.
         /// </summary>
         /// <param name="indexName">The name of the index.</param>
         /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> DeleteIndex(string indexName);
+        Task<bool> DeleteIndex(string indexName);
+    }
 
-        /// <summary>
-        /// Creates or updates a RAG indexer.
-        /// </summary>
-        /// <param name="index">The new definition of the index.</param>
-        /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> UpsertIndexer(IndexMetadata index);
-
+    /// <summary>
+    /// Interface exposing Azure specific operations.
+    /// </summary>
+    public interface IAzureAISearchServiceClient : IAISearchServiceClient
+    {
         /// <summary>
         /// Updates the data in a RAG index, syncing with the corresponding SQL table.
         /// </summary>
         /// <param name="indexName">The name of the index.</param>
         /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> RunIndexer(string indexName);
-
-        /// <summary>
-        /// Deletes a RAG indexer and the associated skillset.
-        /// </summary>
-        /// <param name="indexName">The name of the index.</param>
-        /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> DeleteIndexer(string indexName);
-
-        /// <summary>
-        /// Creates a datasource connection to the SQL database table created for this index.
-        /// </summary>
-        /// <param name="indexName">The name of the index.</param>
-        /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> CreateDatasource(string databaseName);
-
-        /// <summary>
-        /// Deletes a datasource connection to the SQL database table created for this index.
-        /// </summary>
-        /// <param name="indexName">The name of the index.</param>
-        /// <returns>A boolean indicating success or failure of the operation.</returns>
-        public Task<bool> DeleteDatasource(string indexName);
+        Task<bool> RunIndexer(string indexName);
     }
 }

--- a/IntelligenceHub.Tests.Unit/Business/CompletionLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/CompletionLogicTests.cs
@@ -14,6 +14,7 @@ namespace IntelligenceHub.Tests.Unit.Business
     {
         private readonly Mock<IAGIClientFactory> _mockAgiClientFactory;
         private readonly Mock<IAGIClient> _mockAIClient;
+        private readonly Mock<IRagClientFactory> _mockRagClientFactory;
         private readonly Mock<IAISearchServiceClient> _mockSearchClient;
         private readonly Mock<IToolClient> _mockToolClient;
         private readonly Mock<IProfileRepository> _mockProfileRepository;
@@ -26,6 +27,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             _mockAgiClientFactory = new Mock<IAGIClientFactory>();
             _mockAIClient = new Mock<IAGIClient>();
+            _mockRagClientFactory = new Mock<IRagClientFactory>();
             _mockSearchClient = new Mock<IAISearchServiceClient>();
             _mockToolClient = new Mock<IToolClient>();
             _mockProfileRepository = new Mock<IProfileRepository>();
@@ -36,9 +38,11 @@ namespace IntelligenceHub.Tests.Unit.Business
 
             _mockAgiClientFactory.Setup(factory => factory.GetClient(It.IsAny<AGIServiceHost>())).Returns(_mockAIClient.Object);
             
+            _mockRagClientFactory.Setup(f => f.GetClient(It.IsAny<RagServiceHost?>())).Returns(_mockSearchClient.Object);
+
             _completionLogic = new CompletionLogic(
                 _mockAgiClientFactory.Object,
-                _mockSearchClient.Object,
+                _mockRagClientFactory.Object,
                 _mockToolClient.Object,
                 _mockToolRepository.Object,
                 _mockProfileRepository.Object,
@@ -69,7 +73,7 @@ namespace IntelligenceHub.Tests.Unit.Business
 
             var completionLogic = new CompletionLogic(
                 _mockAgiClientFactory.Object,
-                _mockSearchClient.Object,
+                _mockRagClientFactory.Object,
                 _mockToolClient.Object,
                 _mockToolRepository.Object,
                 _mockProfileRepository.Object,


### PR DESCRIPTION
## Summary
- introduce `IAzureAISearchServiceClient` for Azure specific features
- expose high level `CreateIndex`/`DeleteIndex` APIs and move Azure setup logic to clients
- adjust `RagLogic` to use new interfaces
- streamline Weaviate client and remove no-op methods
- update unit tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a7dce8c832e91ec50e46ee38cbe