### PR TITLE
Fix background tasks for Weaviate sync

### DIFF
--- a/IntelligenceHub.Business/Implementations/RagLogic.cs
+++ b/IntelligenceHub.Business/Implementations/RagLogic.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using static IntelligenceHub.Common.GlobalVariables;
 using IntelligenceHub.Common.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using IntelligenceHub.Business.Handlers;
 
 namespace IntelligenceHub.Business.Implementations
@@ -27,6 +28,7 @@ namespace IntelligenceHub.Business.Implementations
         private readonly IIndexRepository _ragRepository;
         private readonly IValidationHandler _validationHandler;
         private readonly IBackgroundTaskQueueHandler _backgroundTaskQueue;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly IntelligenceHubDbContext _dbContext;
         private readonly WeaviateSearchServiceClient _weaviateClient;
 
@@ -44,7 +46,7 @@ namespace IntelligenceHub.Business.Implementations
         /// <param name="validationHandler">A class that can be used to validate DTO bodies passed to the API.</param>
         /// <param name="backgroundTaskQueue">A background task handler useful for performing operations without tying up resources.</param>
         /// <param name="context">DAL context from EFCore used for some more specialized scenarios.</param>
-        public RagLogic(IOptionsMonitor<Settings> settings, IAGIClientFactory agiFactory, IProfileRepository profileRepository, IRagClientFactory ragClientFactory, IIndexMetaRepository metaRepository, IIndexRepository indexRepository, IValidationHandler validationHandler, IBackgroundTaskQueueHandler backgroundTaskQueue, IntelligenceHubDbContext context, WeaviateSearchServiceClient weaviateClient)
+        public RagLogic(IOptionsMonitor<Settings> settings, IAGIClientFactory agiFactory, IProfileRepository profileRepository, IRagClientFactory ragClientFactory, IIndexMetaRepository metaRepository, IIndexRepository indexRepository, IValidationHandler validationHandler, IBackgroundTaskQueueHandler backgroundTaskQueue, IntelligenceHubDbContext context, WeaviateSearchServiceClient weaviateClient, IServiceScopeFactory serviceScopeFactory)
         {
             _defaultAzureModel = settings.CurrentValue.ValidAGIModels.FirstOrDefault() ?? string.Empty;
             _agiClientFactory = agiFactory;
@@ -55,6 +57,7 @@ namespace IntelligenceHub.Business.Implementations
             _backgroundTaskQueue = backgroundTaskQueue;
             _dbContext = context;
             _weaviateClient = weaviateClient;
+            _serviceScopeFactory = serviceScopeFactory;
         }
 
         /// <summary>
@@ -340,7 +343,13 @@ namespace IntelligenceHub.Business.Implementations
             if (indexMetadata.RagHost.ConvertToRagHost() == RagServiceHost.None) return APIResponseWrapper<bool>.Failure($"Failed to convert the RagHost to a valid enum.", APIResponseStatusCodes.InternalError);
             if (indexMetadata.RagHost.ConvertToRagHost() == RagServiceHost.Weaviate)
             {
-                _backgroundTaskQueue.QueueBackgroundWorkItem(async token => await SyncWeaviateIndex(index, token));
+                _backgroundTaskQueue.QueueBackgroundWorkItem(async token =>
+                {
+                    using var scope = _serviceScopeFactory.CreateScope();
+                    var repo = scope.ServiceProvider.GetRequiredService<IIndexRepository>();
+                    var client = scope.ServiceProvider.GetRequiredService<WeaviateSearchServiceClient>();
+                    await SyncWeaviateIndex(index, repo, client, token);
+                });
                 return APIResponseWrapper<bool>.Success(true);
             }
 
@@ -444,7 +453,7 @@ namespace IntelligenceHub.Business.Implementations
             return APIResponseWrapper<int>.Success(deletedDocuments);
         }
 
-        private async Task SyncWeaviateIndex(string index, CancellationToken token)
+        private async Task SyncWeaviateIndex(string index, IIndexRepository repository, WeaviateSearchServiceClient weaviateClient, CancellationToken token)
         {
             const int batch = 100;
             int page = 1;
@@ -452,26 +461,26 @@ namespace IntelligenceHub.Business.Implementations
             IEnumerable<DbIndexDocument> pageDocs;
             do
             {
-                pageDocs = await _ragRepository.GetAllAsync(index, batch, page);
+                pageDocs = await repository.GetAllAsync(index, batch, page);
                 sqlDocs.AddRange(pageDocs);
                 page++;
             } while (pageDocs.Any());
 
-            var weavDocs = await _weaviateClient.GetAllDocuments(index);
+            var weavDocs = await weaviateClient.GetAllDocuments(index);
             var sqlLookup = sqlDocs.ToDictionary(d => d.Id);
 
             foreach (var wdoc in weavDocs)
             {
                 if (!sqlLookup.ContainsKey(wdoc.Id))
                 {
-                    await _weaviateClient.DeleteDocument(index, wdoc.Id);
+                    await weaviateClient.DeleteDocument(index, wdoc.Id);
                 }
             }
 
             foreach (var sdoc in sqlDocs)
             {
                 var dto = DbMappingHandler.MapFromDbIndexDocument(sdoc);
-                await _weaviateClient.UpsertDocument(index, dto);
+                await weaviateClient.UpsertDocument(index, dto);
             }
         }
 

--- a/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
@@ -10,6 +10,7 @@ using IntelligenceHub.Common.Config;
 using IntelligenceHub.DAL;
 using IntelligenceHub.DAL.Interfaces;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System.Reflection;
 using System.Web.Razor.Generator;
@@ -40,13 +41,14 @@ namespace IntelligenceHub.Tests.Unit.Business
             _mockRagRepository = new Mock<IIndexRepository>();
             _mockValidationHandler = new Mock<IValidationHandler>();
             _mockBackgroundTaskQueueHandler = new Mock<IBackgroundTaskQueueHandler>();
+            var mockScopeFactory = new Mock<IServiceScopeFactory>();
             _mockIOptions = new Mock<IOptionsMonitor<Settings>>();
             _context = new Mock<IntelligenceHubDbContext>();
 
             var settings = new Settings { ValidAGIModels = new[] { "Model1", "Model2" } };
             _mockIOptions.Setup(m => m.CurrentValue).Returns(settings);
 
-            _ragLogic = new RagLogic(_mockIOptions.Object, _mockClientFactory.Object, _mockProfileRepository.Object, _mockSearchClient.Object, _mockMetaRepository.Object, _mockRagRepository.Object, _mockValidationHandler.Object, _mockBackgroundTaskQueueHandler.Object, _context.Object, null!);
+            _ragLogic = new RagLogic(_mockIOptions.Object, _mockClientFactory.Object, _mockProfileRepository.Object, _mockSearchClient.Object, _mockMetaRepository.Object, _mockRagRepository.Object, _mockValidationHandler.Object, _mockBackgroundTaskQueueHandler.Object, _context.Object, null!, mockScopeFactory.Object);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- inject IServiceScopeFactory into RagLogic
- create new scope when syncing Weaviate indexes
- update tests for new dependency

## Testing
- `dotnet test IntelligenceHub.Tests.Unit/IntelligenceHub.Tests.Unit.csproj --no-restore` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8d182a00832ea2914c163f529057