### PR TITLE
Implement usage billing filter

### DIFF
--- a/IntelligenceHub.Business/Implementations/CompletionLogic.cs
+++ b/IntelligenceHub.Business/Implementations/CompletionLogic.cs
@@ -231,10 +231,6 @@ namespace IntelligenceHub.Business.Implementations
             if (completion.FinishReason == FinishReasons.Error) return APIResponseWrapper<CompletionResponse>.Failure(completion, "An error was encountered when trying to generate a completion.", APIResponseStatusCodes.InternalError);
             if (completion.FinishReason == FinishReasons.TooManyRequests) return APIResponseWrapper<CompletionResponse>.Failure(completion, $"The Host service quota has been exceeded. Please check your API quota details for '{completionRequest.ProfileOptions.Host}'.", APIResponseStatusCodes.TooManyRequests);
 
-            if (!string.IsNullOrEmpty(completionRequest.ProfileOptions.User))
-            {
-                await _billingService.TrackUsageAsync(completionRequest.ProfileOptions.User, 1);
-            }
 
             if (completionRequest.ConversationId is Guid id)
             {
@@ -479,10 +475,6 @@ namespace IntelligenceHub.Business.Implementations
             var completion = await agiClient.PostCompletion(completionRequest);
             if (completion.FinishReason == FinishReasons.Error) return completion;
 
-            if (!string.IsNullOrEmpty(completionRequest.ProfileOptions.User))
-            {
-                await _billingService.TrackUsageAsync(completionRequest.ProfileOptions.User, 1);
-            }
 
             if (completionRequest.ConversationId is Guid id)
             {

--- a/IntelligenceHub.Common/Config/Settings.cs
+++ b/IntelligenceHub.Common/Config/Settings.cs
@@ -69,6 +69,11 @@ namespace IntelligenceHub.Common.Config
         /// Gets or sets the default host used for image generation.
         /// </summary>
         public string DefaultImageGenHost { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether user provided service credentials should override appsettings.
+        /// </summary>
+        public bool UseUserProvidedCredentials { get; set; }
     }
 }
 

--- a/IntelligenceHub.Controllers/CompletionController.cs
+++ b/IntelligenceHub.Controllers/CompletionController.cs
@@ -10,6 +10,7 @@ using Swashbuckle.AspNetCore.Annotations;
 using System.Net;
 using System.Text;
 using static IntelligenceHub.Common.GlobalVariables;
+using IntelligenceHub.Controllers.Filters;
 
 
 namespace IntelligenceHub.Controllers
@@ -20,6 +21,7 @@ namespace IntelligenceHub.Controllers
     [Route("[controller]")]
     [ApiController]
     [Authorize]
+    [Billable(UsageType.Completion)]
     public class CompletionController : ControllerBase
     {
         private readonly ICompletionLogic _completionLogic;

--- a/IntelligenceHub.Controllers/Filters/BillableAttribute.cs
+++ b/IntelligenceHub.Controllers/Filters/BillableAttribute.cs
@@ -1,0 +1,54 @@
+using IntelligenceHub.Business.Interfaces;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Security.Claims;
+
+namespace IntelligenceHub.Controllers.Filters
+{
+    /// <summary>
+    /// Action filter that records billing information for each request.
+    /// </summary>
+    public class BillableAttribute : ActionFilterAttribute
+    {
+        private readonly UsageType _usageType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BillableAttribute"/> class.
+        /// </summary>
+        /// <param name="usageType">The usage type for billing.</param>
+        public BillableAttribute(UsageType usageType = UsageType.General)
+        {
+            _usageType = usageType;
+        }
+
+        /// <inheritdoc />
+        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var executedContext = await next();
+            if (executedContext.Exception != null) return;
+
+            var billingService = context.HttpContext.RequestServices.GetService(typeof(IBillingService)) as IBillingService;
+            if (billingService == null) return;
+
+            var userId = context.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId)) return;
+
+            var subscriptionItemId = $"{userId}:{_usageType.ToString().ToLower()}";
+            await billingService.TrackUsageAsync(subscriptionItemId, 1);
+        }
+    }
+
+    /// <summary>
+    /// Usage type enumeration for billing metrics.
+    /// </summary>
+    public enum UsageType
+    {
+        /// <summary>
+        /// General API usage.
+        /// </summary>
+        General,
+        /// <summary>
+        /// Completion specific usage.
+        /// </summary>
+        Completion
+    }
+}

--- a/IntelligenceHub.Controllers/MessageHistoryController.cs
+++ b/IntelligenceHub.Controllers/MessageHistoryController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using IntelligenceHub.Controllers.Filters;
 
 namespace IntelligenceHub.Controllers
 {
@@ -15,6 +16,7 @@ namespace IntelligenceHub.Controllers
     [Route("[controller]")]
     [ApiController]
     [Authorize(Policy = ElevatedAuthPolicy)]
+    [Billable]
     public class MessageHistoryController : ControllerBase
     {
         private readonly IMessageHistoryLogic _messageHistoryLogic;

--- a/IntelligenceHub.Controllers/ProfileController.cs
+++ b/IntelligenceHub.Controllers/ProfileController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using Swashbuckle.AspNetCore.Annotations;
 using static IntelligenceHub.Common.GlobalVariables;
+using IntelligenceHub.Controllers.Filters;
 
 namespace IntelligenceHub.Controllers
 {
@@ -16,6 +17,7 @@ namespace IntelligenceHub.Controllers
     [Route("[controller]")]
     [ApiController]
     [Authorize(Policy = ElevatedAuthPolicy)]
+    [Billable]
     public class ProfileController : ControllerBase
     {
         private readonly IProfileLogic _profileLogic;

--- a/IntelligenceHub.Controllers/RagController.cs
+++ b/IntelligenceHub.Controllers/RagController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using IntelligenceHub.Controllers.Filters;
 
 namespace IntelligenceHub.Controllers
 {
@@ -17,6 +18,7 @@ namespace IntelligenceHub.Controllers
     [Route("Rag")]
     [ApiController]
     [Authorize(Policy = ElevatedAuthPolicy)]
+    [Billable]
     public class RagController : ControllerBase
     {
         private readonly IRagLogic _ragLogic;

--- a/IntelligenceHub.Controllers/ToolController.cs
+++ b/IntelligenceHub.Controllers/ToolController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using IntelligenceHub.Controllers.Filters;
 
 namespace IntelligenceHub.Controllers
 {
@@ -15,6 +16,7 @@ namespace IntelligenceHub.Controllers
     [Route("[controller]")]
     [ApiController]
     [Authorize(Policy = ElevatedAuthPolicy)]
+    [Billable]
     public class ToolController : ControllerBase
     {
         private readonly IProfileLogic _profileLogic;

--- a/IntelligenceHub.Host/appsettings.Template.json
+++ b/IntelligenceHub.Host/appsettings.Template.json
@@ -28,7 +28,8 @@
     "ValidAGIModels": [
       "__Settings_ValidAGIModels_0__"
     ],
-    "DefaultImageGenHost": "__Settings_DefaultImageHost__"
+    "DefaultImageGenHost": "__Settings_DefaultImageHost__",
+    "UseUserProvidedCredentials": "__Settings_UseUserProvidedCredentials__"
   },
   "AuthSettings": {
     "BasicUsername": "__AuthSettings_BasicUsername__",

--- a/IntelligenceHub.Tests.Unit/Business/CompletionLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/CompletionLogicTests.cs
@@ -133,7 +133,7 @@ namespace IntelligenceHub.Tests.Unit.Business
             // Assert
             Assert.NotNull(result);
             Assert.Equal(completionResponse, result.Data);
-            _mockBillingService.Verify(b => b.TrackUsageAsync(It.IsAny<string>(), 1), Times.Once);
+            _mockBillingService.Verify(b => b.TrackUsageAsync(It.IsAny<string>(), 1), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- add BillableAttribute to record per-request billing
- track completion requests separately from other controllers
- add optional UseUserProvidedCredentials setting
- update controllers to use billing filter
- remove billing call from completion logic
- adjust tests for billing changes

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754b802630832ea05770121a6bbd20