### PR TITLE
Use DB credentials for clients

### DIFF
--- a/IntelligenceHub.Client/Implementations/AzureAISearchServiceClient.cs
+++ b/IntelligenceHub.Client/Implementations/AzureAISearchServiceClient.cs
@@ -7,7 +7,7 @@ using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
 using IntelligenceHub.API.DTOs.RAG;
 using IntelligenceHub.Client.Interfaces;
-using IntelligenceHub.Common.Config;
+using System.Text;
 using Microsoft.Extensions.Options;
 using static IntelligenceHub.Common.GlobalVariables;
 
@@ -22,6 +22,7 @@ namespace IntelligenceHub.Client.Implementations
         private readonly SearchIndexerClient _indexerClient;
 
         private readonly string _sqlRagDbConnectionString;
+        private readonly IUserCredentialProvider _credentialProvider;
         private readonly string _openaiKey;
         private readonly string _openaiUrl;
 
@@ -63,24 +64,31 @@ namespace IntelligenceHub.Client.Implementations
         /// <summary>
         /// The default constructor for the AISearchServiceClient class.
         /// </summary>
-        /// <param name="searchClientSettings">The search service client resolved from DI.</param>
-        /// <param name="agiClientSettings">The settings for the client resolved from DI.</param>
+        /// <param name="factory">Factory used to create HttpClient instances.</param>
+        /// <param name="credentialProvider">Provider used to load user credentials.</param>
         /// <param name="settings">The application settings passed in from DI. Only required for the DB connection string.</param>
-        public AzureAISearchServiceClient(IOptionsMonitor<AzureSearchServiceClientSettings> searchClientSettings, IOptionsMonitor<AGIClientSettings> agiClientSettings, IOptionsMonitor<Settings> settings)
+        public AzureAISearchServiceClient(IUserCredentialProvider credentialProvider, IOptionsMonitor<Settings> settings)
         {
-            var credential = new AzureKeyCredential(searchClientSettings.CurrentValue.Key);
+            _credentialProvider = credentialProvider;
+            _sqlRagDbConnectionString = settings.CurrentValue.DbConnectionString;
+
+            var ragCred = _credentialProvider.GetCredentialAsync(ServiceTypes.RAG, RagServiceHost.Azure.ToString()).GetAwaiter().GetResult();
+            if (ragCred == null) throw new InvalidOperationException("User credentials not found for Azure Search.");
+            var apiKey = Encoding.UTF8.GetString(Convert.FromBase64String(ragCred.ApiKey));
+            var credential = new AzureKeyCredential(apiKey);
 
             var options = new SearchClientOptions()
             {
                 RetryPolicy = new RetryPolicy(AISearchServiceMaxRetries, DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(AISearchServiceInitialDelay), TimeSpan.FromSeconds(AISearchServiceMaxDelay)))
             };
 
-            _indexClient = new SearchIndexClient(new Uri(searchClientSettings.CurrentValue.Endpoint), credential, options);
-            _indexerClient = new SearchIndexerClient(new Uri(searchClientSettings.CurrentValue.Endpoint), credential, options);
+            _indexClient = new SearchIndexClient(new Uri(ragCred.Endpoint), credential, options);
+            _indexerClient = new SearchIndexerClient(new Uri(ragCred.Endpoint), credential, options);
 
-            _sqlRagDbConnectionString = settings.CurrentValue.DbConnectionString;
-            _openaiUrl = agiClientSettings.CurrentValue.SearchServiceCompletionServiceEndpoint;
-            _openaiKey = agiClientSettings.CurrentValue.SearchServiceCompletionServiceKey;
+            var agiCred = _credentialProvider.GetCredentialAsync(ServiceTypes.AGI, AGIServiceHost.Azure.ToString()).GetAwaiter().GetResult();
+            if (agiCred == null) throw new InvalidOperationException("User AGI credentials not found for Azure Search.");
+            _openaiUrl = agiCred.Endpoint;
+            _openaiKey = Encoding.UTF8.GetString(Convert.FromBase64String(agiCred.ApiKey));
         }
 
         // index operations

--- a/IntelligenceHub.Client/Implementations/UserCredentialProvider.cs
+++ b/IntelligenceHub.Client/Implementations/UserCredentialProvider.cs
@@ -1,0 +1,35 @@
+using IntelligenceHub.Client.Interfaces;
+using IntelligenceHub.DAL.Interfaces;
+using IntelligenceHub.DAL.Models;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace IntelligenceHub.Client.Implementations
+{
+    /// <summary>
+    /// Retrieves user service credentials from the database.
+    /// </summary>
+    public class UserCredentialProvider : IUserCredentialProvider
+    {
+        private readonly IUserServiceCredentialRepository _repository;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public UserCredentialProvider(IUserServiceCredentialRepository repository, IHttpContextAccessor httpContextAccessor)
+        {
+            _repository = repository;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        public async Task<DbUserServiceCredential?> GetCredentialAsync(string serviceType, string? host)
+        {
+            var userId = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId)) return null;
+
+            var creds = await _repository.GetByUserIdAsync(userId);
+            return creds.FirstOrDefault(c =>
+                c.ServiceType.Equals(serviceType, StringComparison.OrdinalIgnoreCase) &&
+                (host == null || (c.Host != null && c.Host.Equals(host, StringComparison.OrdinalIgnoreCase))));
+        }
+    }
+}

--- a/IntelligenceHub.Client/Interfaces/IUserCredentialProvider.cs
+++ b/IntelligenceHub.Client/Interfaces/IUserCredentialProvider.cs
@@ -1,0 +1,16 @@
+namespace IntelligenceHub.Client.Interfaces
+{
+    /// <summary>
+    /// Provides user-specific service credentials.
+    /// </summary>
+    public interface IUserCredentialProvider
+    {
+        /// <summary>
+        /// Retrieves a credential for the current user.
+        /// </summary>
+        /// <param name="serviceType">The service type, e.g. AGI or RAG.</param>
+        /// <param name="host">The optional host/provider name.</param>
+        /// <returns>The credential or null if none were found.</returns>
+        Task<IntelligenceHub.DAL.Models.DbUserServiceCredential?> GetCredentialAsync(string serviceType, string? host);
+    }
+}

--- a/IntelligenceHub.Common/Config/Settings.cs
+++ b/IntelligenceHub.Common/Config/Settings.cs
@@ -70,10 +70,6 @@ namespace IntelligenceHub.Common.Config
         /// </summary>
         public string DefaultImageGenHost { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Gets or sets a value indicating whether user provided service credentials should override appsettings.
-        /// </summary>
-        public bool UseUserProvidedCredentials { get; set; }
     }
 }
 

--- a/IntelligenceHub.Common/GlobalVariables.cs
+++ b/IntelligenceHub.Common/GlobalVariables.cs
@@ -300,5 +300,14 @@
         /// The default tag boost for scoring.
         /// </summary>
         public const int DefaultScoringTagBoost = 1;
+
+        /// <summary>
+        /// Service type identifiers used when retrieving user credentials.
+        /// </summary>
+        public static class ServiceTypes
+        {
+            public const string AGI = "AGI";
+            public const string RAG = "RAG";
+        }
     }
 }

--- a/IntelligenceHub.Host/appsettings.Template.json
+++ b/IntelligenceHub.Host/appsettings.Template.json
@@ -28,8 +28,7 @@
     "ValidAGIModels": [
       "__Settings_ValidAGIModels_0__"
     ],
-    "DefaultImageGenHost": "__Settings_DefaultImageHost__",
-    "UseUserProvidedCredentials": "__Settings_UseUserProvidedCredentials__"
+    "DefaultImageGenHost": "__Settings_DefaultImageHost__"
   },
   "AuthSettings": {
     "BasicUsername": "__AuthSettings_BasicUsername__",
@@ -44,34 +43,5 @@
   "AppInsightSettings": {
     "ConnectionString": "__AppInsightSettings_ConnectionString__"
   },
-  "AGIClientSettings": {
-    "AzureOpenAIServices": [
-      {
-        "Endpoint": "__AGIClientSettings_AzureOpenAIServices_0_Endpoint__",
-        "Key": "__AGIClientSettings_AzureOpenAIServices_0_Key__"
-      }
-    ],
-    "OpenAIServices": [
-      {
-        "Endpoint": "__AGIClientSettings_OpenAIServices_0_Endpoint__",
-        "Key": "__AGIClientSettings_OpenAIServices_0_Key__"
-      }
-    ],
-    "AnthropicServices": [
-      {
-        "Endpoint": "__AGIClientSettings_AnthropicServices_0_Endpoint__",
-        "Key": "__AGIClientSettings_AnthropicServices_0_Key__"
-      }
-    ],
-    "SearchServiceCompletionServiceEndpoint": "__AGIClientSettings_SearchServiceCompletionServiceEndpoint__",
-    "SearchServiceCompletionServiceKey": "__AGIClientSettings_SearchServiceCompletionServiceKey__"
-  },
-  "AzureSearchServiceClientSettings": {
-    "Endpoint": "__AzureSearchServiceClientSettings_Endpoint__",
-    "Key": "__AzureSearchServiceClientSettings_Key__"
-  },
-  "WeaviateSearchServiceClientSettings": {
-    "Endpoint": "__WeaviateSearchServiceClientSettings_Endpoint__",
-    "Key": "__WeaviateSearchServiceClientSettings_Key__"
-  }
+  
 }

--- a/infrastructure/env_setup.py
+++ b/infrastructure/env_setup.py
@@ -65,19 +65,7 @@ required_env_vars = [
     "AuthSettings_AdminClientId",
     "AuthSettings_AdminClientSecret",
     "AppInsightSettings_ConnectionString",
-    "AGIClientSettings_AzureOpenAIServices_0_Endpoint",
-    "AGIClientSettings_AzureOpenAIServices_0_Key",
-    "AGIClientSettings_OpenAIServices_0_Endpoint",
-    "AGIClientSettings_OpenAIServices_0_Key",
-    "AGIClientSettings_AnthropicServices_0_Endpoint",
-    "AGIClientSettings_AnthropicServices_0_Key",
-    "AGIClientSettings_SearchServiceCompletionServiceEndpoint",
-    "AGIClientSettings_SearchServiceCompletionServiceKey",
-    "AzureSearchServiceClientSettings_Endpoint",
-    "AzureSearchServiceClientSettings_Key",
     "Settings_DefaultImageHost",  # token for DefaultImageGenHost
-    "WeaviateSearchServiceClientSettings_Endpoint",
-    "WeaviateSearchServiceClientSettings_Key"
 ]
 
 # Check the current environment
@@ -131,9 +119,6 @@ for service_type in additional_services.keys():
             break
         else:
             print("Please enter 'y' for yes or 'n' for no.")
-for service_type, services in additional_services.items():
-    if services:
-        replacements[f"AGIClientSettings_{service_type}"] = services
 
 # Prompt for multiple ValidOrigins entries
 if "Settings_ValidOrigins" not in replacements:


### PR DESCRIPTION
## Summary
- rely on user-provided credentials from the database
- add provider service to supply credentials per request
- remove `UseUserProvidedCredentials` setting
- update service registrations
- drop unused config values and env vars

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875529e8aac832eb84e1c5b9e305f83