### PR TITLE
Allow background worker to resolve user credentials

### DIFF
--- a/IntelligenceHub.Client/Implementations/UserCredentialProvider.cs
+++ b/IntelligenceHub.Client/Implementations/UserCredentialProvider.cs
@@ -2,6 +2,7 @@ using IntelligenceHub.Client.Interfaces;
 using IntelligenceHub.DAL.Interfaces;
 using IntelligenceHub.DAL.Models;
 using Microsoft.AspNetCore.Http;
+using IntelligenceHub.Common.Interfaces;
 using System.Security.Claims;
 
 namespace IntelligenceHub.Client.Implementations
@@ -13,17 +14,19 @@ namespace IntelligenceHub.Client.Implementations
     {
         private readonly IUserServiceCredentialRepository _repository;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IUserIdAccessor _userIdAccessor;
 
-        public UserCredentialProvider(IUserServiceCredentialRepository repository, IHttpContextAccessor httpContextAccessor)
+        public UserCredentialProvider(IUserServiceCredentialRepository repository, IHttpContextAccessor httpContextAccessor, IUserIdAccessor userIdAccessor)
         {
             _repository = repository;
             _httpContextAccessor = httpContextAccessor;
+            _userIdAccessor = userIdAccessor;
         }
 
         /// <inheritdoc />
         public async Task<DbUserServiceCredential?> GetCredentialAsync(string serviceType, string? host)
         {
-            var userId = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var userId = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? _userIdAccessor.UserId;
             if (string.IsNullOrEmpty(userId)) return null;
 
             var creds = await _repository.GetByUserIdAsync(userId);

--- a/IntelligenceHub.Common/Implementations/UserIdAccessor.cs
+++ b/IntelligenceHub.Common/Implementations/UserIdAccessor.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using IntelligenceHub.Common.Interfaces;
+
+namespace IntelligenceHub.Common.Implementations
+{
+    /// <summary>
+    /// Default implementation storing the user identifier in an <see cref="AsyncLocal{T}"/> variable.
+    /// </summary>
+    public class UserIdAccessor : IUserIdAccessor
+    {
+        private static readonly AsyncLocal<string?> _currentUserId = new();
+
+        /// <inheritdoc />
+        public string? UserId
+        {
+            get => _currentUserId.Value;
+            set => _currentUserId.Value = value;
+        }
+    }
+}

--- a/IntelligenceHub.Common/Interfaces/IUserIdAccessor.cs
+++ b/IntelligenceHub.Common/Interfaces/IUserIdAccessor.cs
@@ -1,0 +1,13 @@
+namespace IntelligenceHub.Common.Interfaces
+{
+    /// <summary>
+    /// Provides access to the current user identifier for background operations.
+    /// </summary>
+    public interface IUserIdAccessor
+    {
+        /// <summary>
+        /// Gets or sets the current user identifier.
+        /// </summary>
+        string? UserId { get; set; }
+    }
+}

--- a/IntelligenceHub.Host/Middleware/UserContextMiddleware.cs
+++ b/IntelligenceHub.Host/Middleware/UserContextMiddleware.cs
@@ -1,0 +1,34 @@
+using System.Security.Claims;
+using IntelligenceHub.Common.Interfaces;
+
+namespace IntelligenceHub.Host.Middleware
+{
+    /// <summary>
+    /// Middleware that populates the <see cref="IUserIdAccessor"/> with the authenticated user identifier.
+    /// </summary>
+    public class UserContextMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserContextMiddleware"/> class.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        public UserContextMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        /// <summary>
+        /// Sets the current user identifier on the <see cref="IUserIdAccessor"/> and continues the pipeline.
+        /// </summary>
+        /// <param name="context">The current HTTP context.</param>
+        /// <param name="accessor">Accessor used to store the user identifier.</param>
+        /// <returns>An awaitable task.</returns>
+        public async Task InvokeAsync(HttpContext context, IUserIdAccessor accessor)
+        {
+            accessor.UserId = context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            await _next(context);
+        }
+    }
+}

--- a/IntelligenceHub.Host/Program.cs
+++ b/IntelligenceHub.Host/Program.cs
@@ -24,6 +24,9 @@ using IntelligenceHub.Business.Factories;
 using IntelligenceHub.Host.Swagger;
 using IntelligenceHub.Business.Handlers;
 using Microsoft.AspNetCore.Authentication;
+using IntelligenceHub.Common.Interfaces;
+using IntelligenceHub.Common.Implementations;
+using IntelligenceHub.Host.Middleware;
 
 namespace IntelligenceHub.Host
 {
@@ -85,6 +88,7 @@ namespace IntelligenceHub.Host
 
             // Clients and Client Factory
             builder.Services.AddHttpContextAccessor();
+            builder.Services.AddSingleton<IUserIdAccessor, UserIdAccessor>();
             builder.Services.AddScoped<IUserCredentialProvider, UserCredentialProvider>();
 
             builder.Services.AddScoped<IAGIClientFactory, AGIClientFactory>();
@@ -329,6 +333,7 @@ namespace IntelligenceHub.Host
             app.UseMiddleware<LoggingMiddleware>();
 
             app.UseAuthentication();
+            app.UseMiddleware<UserContextMiddleware>();
             app.UseAuthorization();
 
             app.MapControllers();

--- a/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Web.Razor.Generator;
 using IntelligenceHub.Business.Interfaces;
 using static IntelligenceHub.Common.GlobalVariables;
+using IntelligenceHub.Common.Interfaces;
 
 namespace IntelligenceHub.Tests.Unit.Business
 {
@@ -47,6 +48,7 @@ namespace IntelligenceHub.Tests.Unit.Business
             _mockValidationHandler = new Mock<IValidationHandler>();
             _mockBackgroundTaskQueueHandler = new Mock<IBackgroundTaskQueueHandler>();
             _mockBillingService = new Mock<IBillingService>();
+            var mockUserIdAccessor = new Mock<IUserIdAccessor>();
             var mockScopeFactory = new Mock<IServiceScopeFactory>();
             _mockIOptions = new Mock<IOptionsMonitor<Settings>>();
             _context = new Mock<IntelligenceHubDbContext>();
@@ -54,7 +56,7 @@ namespace IntelligenceHub.Tests.Unit.Business
             var settings = new Settings { ValidAGIModels = new[] { "Model1", "Model2" } };
             _mockIOptions.Setup(m => m.CurrentValue).Returns(settings);
 
-            _ragLogic = new RagLogic(_mockIOptions.Object, _mockClientFactory.Object, _mockProfileRepository.Object, _mockRagClientFactory.Object, _mockMetaRepository.Object, _mockRagRepository.Object, _mockValidationHandler.Object, _mockBackgroundTaskQueueHandler.Object, _context.Object, null!, mockScopeFactory.Object, _mockBillingService.Object);
+            _ragLogic = new RagLogic(_mockIOptions.Object, _mockClientFactory.Object, _mockProfileRepository.Object, _mockRagClientFactory.Object, _mockMetaRepository.Object, _mockRagRepository.Object, _mockValidationHandler.Object, _mockBackgroundTaskQueueHandler.Object, _context.Object, null!, mockScopeFactory.Object, _mockBillingService.Object, mockUserIdAccessor.Object);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- add `IUserIdAccessor` with a default `UserIdAccessor`
- populate the accessor via new `UserContextMiddleware`
- inject the accessor into `UserCredentialProvider` and `RagLogic`
- preserve user id for background tasks

## Testing
- `dotnet test IntelligenceHub.sln`

------
https://chatgpt.com/codex/tasks/task_e_68796d73ada8832eb068036852fd34a7