### PR TITLE
Add feature flag for Azure Search

### DIFF
--- a/IntelligenceHub.API/DTOs/RAG/IndexMetadata.cs
+++ b/IntelligenceHub.API/DTOs/RAG/IndexMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using static IntelligenceHub.Common.GlobalVariables;
+using System.Text.Json.Serialization;
 
 namespace IntelligenceHub.API.DTOs.RAG
 {
@@ -20,41 +21,49 @@ namespace IntelligenceHub.API.DTOs.RAG
         /// <summary>
         /// Gets or sets the host used for generating vector embeddings.
         /// </summary>
+        [JsonIgnore]
         public AGIServiceHost? GenerationHost { get; set; }
 
         /// <summary>
         /// Gets or sets the service that stores the vectors.
         /// </summary>
+        [JsonIgnore]
         public RagServiceHost? RagHost { get; set; }
 
         /// <summary>
         /// Gets or sets how frequently the index should be rebuilt.
         /// </summary>
+        [JsonIgnore]
         public TimeSpan? IndexingInterval { get; set; }
 
         /// <summary>
         /// Gets or sets the embedding model used for vectorization.
         /// </summary>
+        [JsonIgnore]
         public string? EmbeddingModel { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of attachments to return in RAG queries.
         /// </summary>
+        [JsonIgnore]
         public int? MaxRagAttachments { get; set; }
 
         /// <summary>
         /// Gets or sets the overlap between adjacent chunks of text.
         /// </summary>
+        [JsonIgnore]
         public double? ChunkOverlap { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the topic should be generated.
         /// </summary>
+        [JsonIgnore]
         public bool? GenerateTopic { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether keywords should be generated.
         /// </summary>
+        [JsonIgnore]
         public bool? GenerateKeywords { get; set; }
 
         /// <summary>
@@ -80,6 +89,7 @@ namespace IntelligenceHub.API.DTOs.RAG
         /// <summary>
         /// Gets or sets the scoring profile applied when ranking results.
         /// </summary>
+        [JsonIgnore]
         public IndexScoringProfile? ScoringProfile { get; set; } = new IndexScoringProfile();
     }
 }

--- a/IntelligenceHub.API/DTOs/RAG/IndexMetadata.cs
+++ b/IntelligenceHub.API/DTOs/RAG/IndexMetadata.cs
@@ -21,49 +21,45 @@ namespace IntelligenceHub.API.DTOs.RAG
         /// <summary>
         /// Gets or sets the host used for generating vector embeddings.
         /// </summary>
-        [JsonIgnore]
         public AGIServiceHost? GenerationHost { get; set; }
 
         /// <summary>
         /// Gets or sets the service that stores the vectors.
         /// </summary>
         [JsonIgnore]
-        public RagServiceHost? RagHost { get; set; }
+        public RagServiceHost? RagHost { get; set; } = RagServiceHost.Weaviate; // Weaviate is currently only supported and does not support this value
 
         /// <summary>
         /// Gets or sets how frequently the index should be rebuilt.
         /// </summary>
         [JsonIgnore]
-        public TimeSpan? IndexingInterval { get; set; }
+        public TimeSpan? IndexingInterval { get; set; } // Weaviate is currently only supported and does not support this value
 
         /// <summary>
         /// Gets or sets the embedding model used for vectorization.
         /// </summary>
         [JsonIgnore]
-        public string? EmbeddingModel { get; set; }
+        public string? EmbeddingModel { get; set; } = DefaultWeaviateEmbeddingModel; // Weaviate is currently only supported and does not support this value
 
         /// <summary>
         /// Gets or sets the maximum number of attachments to return in RAG queries.
         /// </summary>
-        [JsonIgnore]
         public int? MaxRagAttachments { get; set; }
 
         /// <summary>
         /// Gets or sets the overlap between adjacent chunks of text.
         /// </summary>
         [JsonIgnore]
-        public double? ChunkOverlap { get; set; }
+        public double? ChunkOverlap { get; set; } // Weaviate is currently only supported and does not support this value
 
         /// <summary>
         /// Gets or sets a value indicating whether the topic should be generated.
         /// </summary>
-        [JsonIgnore]
         public bool? GenerateTopic { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether keywords should be generated.
         /// </summary>
-        [JsonIgnore]
         public bool? GenerateKeywords { get; set; }
 
         /// <summary>
@@ -90,6 +86,6 @@ namespace IntelligenceHub.API.DTOs.RAG
         /// Gets or sets the scoring profile applied when ranking results.
         /// </summary>
         [JsonIgnore]
-        public IndexScoringProfile? ScoringProfile { get; set; } = new IndexScoringProfile();
+        public IndexScoringProfile? ScoringProfile { get; set; } = new IndexScoringProfile(); // Weaviate is currently only supported and does not support this value
     }
 }

--- a/IntelligenceHub.Business/Implementations/FeatureFlagService.cs
+++ b/IntelligenceHub.Business/Implementations/FeatureFlagService.cs
@@ -1,0 +1,26 @@
+using IntelligenceHub.Business.Interfaces;
+using IntelligenceHub.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace IntelligenceHub.Business.Implementations
+{
+    /// <summary>
+    /// Default implementation of <see cref="IFeatureFlagService"/>.
+    /// </summary>
+    public class FeatureFlagService : IFeatureFlagService
+    {
+        private readonly IOptionsMonitor<FeatureFlagSettings> _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeatureFlagService"/> class.
+        /// </summary>
+        /// <param name="options">The feature flag options.</param>
+        public FeatureFlagService(IOptionsMonitor<FeatureFlagSettings> options)
+        {
+            _options = options;
+        }
+
+        /// <inheritdoc />
+        public bool UseAzureAISearch => _options.CurrentValue.UseAzureAISearch;
+    }
+}

--- a/IntelligenceHub.Business/Interfaces/IFeatureFlagService.cs
+++ b/IntelligenceHub.Business/Interfaces/IFeatureFlagService.cs
@@ -1,0 +1,13 @@
+namespace IntelligenceHub.Business.Interfaces
+{
+    /// <summary>
+    /// Provides access to application feature flags.
+    /// </summary>
+    public interface IFeatureFlagService
+    {
+        /// <summary>
+        /// Gets a value indicating whether Azure AI Search is enabled.
+        /// </summary>
+        bool UseAzureAISearch { get; }
+    }
+}

--- a/IntelligenceHub.Common/Config/FeatureFlagSettings.cs
+++ b/IntelligenceHub.Common/Config/FeatureFlagSettings.cs
@@ -1,0 +1,13 @@
+namespace IntelligenceHub.Common.Config
+{
+    /// <summary>
+    /// Configuration for application feature flags.
+    /// </summary>
+    public class FeatureFlagSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether Azure AI Search is enabled.
+        /// </summary>
+        public bool UseAzureAISearch { get; set; }
+    }
+}

--- a/IntelligenceHub.Host/Program.cs
+++ b/IntelligenceHub.Host/Program.cs
@@ -54,11 +54,13 @@ namespace IntelligenceHub.Host
 
             var agiClientSettingsSection = builder.Configuration.GetRequiredSection(nameof(AGIClientSettings));
             var agiClientSettings = agiClientSettingsSection.Get<AGIClientSettings>();
+            var featureFlagsSection = builder.Configuration.GetSection(nameof(FeatureFlagSettings));
 
             builder.Services.Configure<Settings>(settingsSection);
             builder.Services.Configure<AuthSettings>(authSection);
             builder.Services.Configure<AppInsightSettings>(insightSettingsSection);
             builder.Services.Configure<AGIClientSettings>(agiClientSettingsSection);
+            builder.Services.Configure<FeatureFlagSettings>(featureFlagsSection);
             builder.Services.Configure<AzureSearchServiceClientSettings>(builder.Configuration.GetRequiredSection(nameof(AzureSearchServiceClientSettings)));
             builder.Services.Configure<WeaviateSearchServiceClientSettings>(builder.Configuration.GetSection(nameof(WeaviateSearchServiceClientSettings)));
 
@@ -123,6 +125,7 @@ namespace IntelligenceHub.Host
             builder.Services.AddSingleton<IValidationHandler, ValidationHandler>();
             builder.Services.AddSingleton<IBackgroundTaskQueueHandler, BackgroundTaskQueueHandler>();
             builder.Services.AddHostedService<BackgroundWorker>();
+            builder.Services.AddSingleton<IFeatureFlagService, FeatureFlagService>();
 
             #endregion
 

--- a/IntelligenceHub.Host/appsettings.Template.json
+++ b/IntelligenceHub.Host/appsettings.Template.json
@@ -72,5 +72,8 @@
   "WeaviateSearchServiceClientSettings": {
     "Endpoint": "__WeaviateSearchServiceClientSettings_Endpoint__",
     "Key": "__WeaviateSearchServiceClientSettings_Key__"
+  },
+  "FeatureFlagSettings": {
+    "UseAzureAISearch": "__FeatureFlagSettings_UseAzureAISearch__"
   }
 }

--- a/infrastructure/env_setup.py
+++ b/infrastructure/env_setup.py
@@ -77,7 +77,8 @@ required_env_vars = [
     "AzureSearchServiceClientSettings_Key",
     "Settings_DefaultImageHost",  # token for DefaultImageGenHost
     "WeaviateSearchServiceClientSettings_Endpoint",
-    "WeaviateSearchServiceClientSettings_Key"
+    "WeaviateSearchServiceClientSettings_Key",
+    "FeatureFlagSettings_UseAzureAISearch"
 ]
 
 # Check the current environment


### PR DESCRIPTION
## Summary
- add feature flag settings and service
- block Azure index operations if feature disabled
- expose flags via configuration
- register FeatureFlagService and tests
- update env setup template
- hide Azure-only fields in index metadata

## Testing
- `dotnet build IntelligenceHub.sln -c Release`
- `dotnet test IntelligenceHub.Tests.Unit/IntelligenceHub.Tests.Unit.csproj -c Release --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_687aea09dd3c832e806154ebe0f70602