### PR TITLE
Add unit tests for remaining DAL repositories

### DIFF
--- a/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
@@ -250,7 +250,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexMetadata = new IndexMetadata { Name = "testIndex" };
-            var dbIndexMetadata = new DbIndexMetadata { Name = indexMetadata.Name, GenerationHost = AGIServiceHost.Azure.ToString(), GenerateKeywords = false, GenerateTopic = false }; // To vastly simplify testing, these are set to false for the time being
+            var dbIndexMetadata = new DbIndexMetadata { Name = indexMetadata.Name, GenerationHost = AGIServiceHost.Azure.ToString(), RagHost = RagServiceHost.Weaviate.ToString(), GenerateKeywords = false, GenerateTopic = false }; // To vastly simplify testing, these are set to false for the time being
             _mockValidationHandler.Setup(v => v.ValidateIndexDefinition(indexMetadata)).Returns(string.Empty);
             _mockMetaRepository.Setup(repo => repo.GetByNameAsync(indexMetadata.Name)).ReturnsAsync(dbIndexMetadata);
             _mockSearchClient.Setup(client => client.UpsertIndex(indexMetadata)).ReturnsAsync(true);
@@ -270,7 +270,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexMetadata = new IndexMetadata { Name = "testIndex", GenerateContentVector = true };
-            var dbIndexMetadata = new DbIndexMetadata { Name = indexMetadata.Name, GenerateContentVector = false, GenerationHost = AGIServiceHost.Azure.ToString() };
+            var dbIndexMetadata = new DbIndexMetadata { Name = indexMetadata.Name, GenerateContentVector = false, GenerationHost = AGIServiceHost.Azure.ToString(), RagHost = RagServiceHost.Weaviate.ToString() };
             _mockValidationHandler.Setup(v => v.ValidateIndexDefinition(indexMetadata)).Returns(string.Empty);
             _mockMetaRepository.Setup(repo => repo.GetByNameAsync(indexMetadata.Name)).ReturnsAsync(dbIndexMetadata);
             _mockSearchClient.Setup(client => client.UpsertIndex(indexMetadata)).ReturnsAsync(true);

--- a/IntelligenceHub.Tests.Unit/DAL/DbMappingHandlerTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/DbMappingHandlerTests.cs
@@ -365,6 +365,7 @@ namespace IntelligenceHub.Tests.Unit.DAL
                 Name = "Test Name",
                 QueryType = QueryType.Simple,
                 GenerationHost = AGIServiceHost.OpenAI,
+                RagHost = RagServiceHost.Azure,
                 ChunkOverlap = 0.5,
                 IndexingInterval = TimeSpan.FromHours(24),
                 MaxRagAttachments = 5,

--- a/IntelligenceHub.Tests.Unit/DAL/IndexMetaRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/IndexMetaRepositoryTests.cs
@@ -1,0 +1,66 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class IndexMetaRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsItem_ForMatchingTenant()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var expected = new DbIndexMetadata
+            {
+                Name = "index1",
+                GenerationHost = "host",
+                RagHost = "rag",
+                IndexingInterval = TimeSpan.FromHours(1),
+                TenantId = _tenantProvider.TenantId.Value
+            };
+            context.IndexMetadata.Add(expected);
+            context.IndexMetadata.Add(new DbIndexMetadata
+            {
+                Name = "index1",
+                GenerationHost = "host",
+                RagHost = "rag",
+                IndexingInterval = TimeSpan.FromHours(1),
+                TenantId = Guid.NewGuid()
+            });
+            await context.SaveChangesAsync();
+
+            var repo = new IndexMetaRepository(context, _tenantProvider);
+            var result = await repo.GetByNameAsync("index1");
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.Id, result!.Id);
+            Assert.Equal(_tenantProvider.TenantId, result.TenantId);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsNull_WhenNotFound()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var repo = new IndexMetaRepository(context, _tenantProvider);
+
+            var result = await repo.GetByNameAsync("missing");
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/MessageHistoryRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/MessageHistoryRepositoryTests.cs
@@ -1,0 +1,91 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class MessageHistoryRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        private DbMessage CreateMessage(Guid conversationId, DateTime ts)
+        {
+            return new DbMessage
+            {
+                ConversationId = conversationId,
+                Role = "user",
+                TimeStamp = ts,
+                Content = "hi",
+                TenantId = _tenantProvider.TenantId!.Value
+            };
+        }
+
+        [Fact]
+        public async Task GetConversationAsync_ReturnsOrderedPage()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            var conv = Guid.NewGuid();
+            await using var context = CreateContext();
+            context.Messages.AddRange(
+                CreateMessage(conv, new DateTime(2024,1,1)),
+                CreateMessage(conv, new DateTime(2024,1,2)),
+                CreateMessage(conv, new DateTime(2024,1,3)),
+                CreateMessage(Guid.NewGuid(), DateTime.UtcNow)
+            );
+            await context.SaveChangesAsync();
+
+            var repo = new MessageHistoryRepository(context, _tenantProvider);
+            var results = await repo.GetConversationAsync(conv, 2, 1);
+
+            Assert.Equal(2, results.Count);
+            Assert.True(results[0].TimeStamp < results[1].TimeStamp);
+        }
+
+        [Fact]
+        public async Task DeleteConversationAsync_RemovesMessages()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            var conv = Guid.NewGuid();
+            await using var context = CreateContext();
+            context.Messages.AddRange(
+                CreateMessage(conv, DateTime.UtcNow),
+                CreateMessage(conv, DateTime.UtcNow.AddMinutes(1))
+            );
+            await context.SaveChangesAsync();
+
+            var repo = new MessageHistoryRepository(context, _tenantProvider);
+            var result = await repo.DeleteConversationAsync(conv);
+
+            Assert.True(result);
+            Assert.Empty(context.Messages.Where(m => m.ConversationId == conv));
+        }
+
+        [Fact]
+        public async Task DeleteAsync_RemovesSingleMessage()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            var conv = Guid.NewGuid();
+            await using var context = CreateContext();
+            var msg = CreateMessage(conv, DateTime.UtcNow);
+            context.Messages.Add(msg);
+            await context.SaveChangesAsync();
+
+            var repo = new MessageHistoryRepository(context, _tenantProvider);
+            var result = await repo.DeleteAsync(conv, msg.Id);
+
+            Assert.True(result);
+            Assert.Empty(context.Messages);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/ProfileRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/ProfileRepositoryTests.cs
@@ -1,0 +1,67 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class ProfileRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        private async Task SeedAsync(IntelligenceHubDbContext context)
+        {
+            var tool = new DbTool { Name = "tool1", Description="d", Required="r", TenantId=_tenantProvider.TenantId!.Value };
+            context.Tools.Add(tool);
+            await context.SaveChangesAsync();
+            var prop = new DbProperty { Name="p", Type="t", Description="d", ToolId=tool.Id, Tool=tool, TenantId=_tenantProvider.TenantId!.Value };
+            context.Properties.Add(prop);
+            var profile = new DbProfile { Name="profile1", Model="m", Host="h", TenantId=_tenantProvider.TenantId!.Value };
+            context.Profiles.Add(profile);
+            await context.SaveChangesAsync();
+            context.ProfileTools.Add(new DbProfileTool{ ProfileID=profile.Id, ToolID=tool.Id, Profile=profile, Tool=tool, TenantId=_tenantProvider.TenantId!.Value });
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsProfileWithTools()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            await SeedAsync(context);
+            var repo = new ProfileRepository(context, _tenantProvider);
+
+            var result = await repo.GetByNameAsync("profile1");
+
+            Assert.NotNull(result);
+            Assert.Single(result!.ProfileTools);
+            Assert.Equal("tool1", result.ProfileTools.First().Tool.Name);
+            Assert.Single(result.ProfileTools.First().Tool.Properties);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsProfileById()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            await SeedAsync(context);
+            var repo = new ProfileRepository(context, _tenantProvider);
+            var id = context.Profiles.Single().Id;
+
+            var result = await repo.GetAsync(id);
+
+            Assert.NotNull(result);
+            Assert.Equal(id, result!.Id);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/ProfileToolsAssociativeRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/ProfileToolsAssociativeRepositoryTests.cs
@@ -1,0 +1,79 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class ProfileToolsAssociativeRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        private async Task<(DbProfile profile, DbTool tool)> SeedAsync(IntelligenceHubDbContext context)
+        {
+            var profile = new DbProfile { Name="p1", Model="m", Host="h", TenantId=_tenantProvider.TenantId!.Value };
+            var tool = new DbTool { Name="t1", Description="d", Required="r", TenantId=_tenantProvider.TenantId!.Value };
+            context.Profiles.Add(profile);
+            context.Tools.Add(tool);
+            await context.SaveChangesAsync();
+            context.ProfileTools.Add(new DbProfileTool { ProfileID=profile.Id, ToolID=tool.Id, Profile=profile, Tool=tool, TenantId=_tenantProvider.TenantId!.Value });
+            await context.SaveChangesAsync();
+            return (profile, tool);
+        }
+
+        [Fact]
+        public async Task GetToolAssociationsAsync_ReturnsAssociations()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var (profile, _) = await SeedAsync(context);
+            var repo = new ProfileToolsAssociativeRepository(context, _tenantProvider);
+
+            var result = await repo.GetToolAssociationsAsync(profile.Id);
+
+            Assert.Single(result);
+            Assert.Equal(profile.Id, result[0].ProfileID);
+        }
+
+        [Fact]
+        public async Task AddAssociationsByProfileIdAsync_AddsNewAssociations()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var (profile, tool) = await SeedAsync(context);
+            var tool2 = new DbTool { Name="t2", Description="d", Required="r", TenantId=_tenantProvider.TenantId!.Value };
+            context.Tools.Add(tool2);
+            await context.SaveChangesAsync();
+            var repo = new ProfileToolsAssociativeRepository(context, _tenantProvider);
+
+            var result = await repo.AddAssociationsByProfileIdAsync(profile.Id, new List<int>{tool2.Id});
+
+            Assert.True(result);
+            Assert.Equal(2, context.ProfileTools.Count());
+        }
+
+        [Fact]
+        public async Task DeleteToolAssociationAsync_RemovesAssociation()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var (profile, tool) = await SeedAsync(context);
+            var repo = new ProfileToolsAssociativeRepository(context, _tenantProvider);
+
+            var result = await repo.DeleteToolAssociationAsync(tool.Id, profile.Name);
+
+            Assert.True(result);
+            Assert.Empty(context.ProfileTools);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/PropertyRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/PropertyRepositoryTests.cs
@@ -1,0 +1,42 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class PropertyRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        [Fact]
+        public async Task GetToolProperties_ReturnsOnlyForTool()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            var tool1 = new DbTool { Name="t1", Description="d", Required="r", TenantId=_tenantProvider.TenantId.Value };
+            var tool2 = new DbTool { Name="t2", Description="d", Required="r", TenantId=_tenantProvider.TenantId.Value };
+            context.Tools.AddRange(tool1, tool2);
+            await context.SaveChangesAsync();
+            context.Properties.Add(new DbProperty { Name="p1", Type="string", Description="d", ToolId=tool1.Id, Tool=tool1, TenantId=_tenantProvider.TenantId.Value });
+            context.Properties.Add(new DbProperty { Name="p2", Type="string", Description="d", ToolId=tool2.Id, Tool=tool2, TenantId=_tenantProvider.TenantId.Value });
+            await context.SaveChangesAsync();
+
+            var repo = new PropertyRepository(context, _tenantProvider);
+            var result = await repo.GetToolProperties(tool1.Id);
+
+            Assert.Single(result);
+            Assert.Equal("p1", result.First().Name);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/ToolRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/ToolRepositoryTests.cs
@@ -1,0 +1,81 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using IntelligenceHub.DAL.Tenant;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class ToolRepositoryTests
+    {
+        private readonly TenantProvider _tenantProvider = new TenantProvider();
+
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        private async Task SeedAsync(IntelligenceHubDbContext context)
+        {
+            var tool1 = new DbTool { Name="t1", Description="d", Required="r", TenantId=_tenantProvider.TenantId!.Value };
+            var tool2 = new DbTool { Name="t2", Description="d", Required="r", TenantId=_tenantProvider.TenantId!.Value };
+            context.Tools.AddRange(tool1, tool2);
+            await context.SaveChangesAsync();
+            var profile = new DbProfile { Name="p1", Model="m", Host="h", TenantId=_tenantProvider.TenantId!.Value };
+            context.Profiles.Add(profile);
+            await context.SaveChangesAsync();
+            context.ProfileTools.AddRange(
+                new DbProfileTool { ProfileID=profile.Id, ToolID=tool1.Id, Profile=profile, Tool=tool1, TenantId=_tenantProvider.TenantId!.Value },
+                new DbProfileTool { ProfileID=profile.Id, ToolID=tool2.Id, Profile=profile, Tool=tool2, TenantId=_tenantProvider.TenantId!.Value }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsTool()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            await SeedAsync(context);
+            var repo = new ToolRepository(context, _tenantProvider);
+
+            var result = await repo.GetByNameAsync("t1");
+
+            Assert.NotNull(result);
+            Assert.Equal("t1", result!.Name);
+        }
+
+        [Fact]
+        public async Task GetProfileToolsAsync_ReturnsToolNames()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            await SeedAsync(context);
+            var repo = new ToolRepository(context, _tenantProvider);
+
+            var result = await repo.GetProfileToolsAsync("p1");
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains("t1", result);
+            Assert.Contains("t2", result);
+        }
+
+        [Fact]
+        public async Task GetToolProfilesAsync_ReturnsProfileNames()
+        {
+            _tenantProvider.TenantId = Guid.NewGuid();
+            await using var context = CreateContext();
+            await SeedAsync(context);
+            var repo = new ToolRepository(context, _tenantProvider);
+
+            var result = await repo.GetToolProfilesAsync("t1");
+
+            Assert.Single(result);
+            Assert.Equal("p1", result[0]);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/DAL/UserRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/UserRepositoryTests.cs
@@ -1,0 +1,65 @@
+using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Implementations;
+using IntelligenceHub.DAL.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntelligenceHub.Tests.Unit.DAL
+{
+    public class UserRepositoryTests
+    {
+        private IntelligenceHubDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<IntelligenceHubDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new IntelligenceHubDbContext(options);
+        }
+
+        [Fact]
+        public async Task GetBySubAsync_ReturnsUser()
+        {
+            await using var context = CreateContext();
+            var user = new DbUser { Sub="sub", ApiToken="token", TenantId=Guid.NewGuid() };
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+            var repo = new UserRepository(context);
+
+            var result = await repo.GetBySubAsync("sub");
+
+            Assert.NotNull(result);
+            Assert.Equal(user.Id, result!.Id);
+        }
+
+        [Fact]
+        public async Task GetByApiTokenAsync_ReturnsUser()
+        {
+            await using var context = CreateContext();
+            var user = new DbUser { Sub="s", ApiToken="token", TenantId=Guid.NewGuid() };
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+            var repo = new UserRepository(context);
+
+            var result = await repo.GetByApiTokenAsync("token");
+
+            Assert.NotNull(result);
+            Assert.Equal(user.Id, result!.Id);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_UpdatesUser()
+        {
+            await using var context = CreateContext();
+            var user = new DbUser { Sub="s", ApiToken="t", TenantId=Guid.NewGuid(), AccessLevel="Free" };
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+            var repo = new UserRepository(context);
+
+            user.AccessLevel = "Pro";
+            var updated = await repo.UpdateAsync(user);
+
+            Assert.Equal("Pro", updated.AccessLevel);
+            Assert.Equal("Pro", (await context.Users.FindAsync(user.Id))!.AccessLevel);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand DAL test coverage with new repository tests
- fix failing mapping and rag logic unit tests by specifying `RagHost`

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687af4eace30832e9b9a2ac753db2a9c