### PR TITLE
Add unit tests for service factories and logic

### DIFF
--- a/IntelligenceHub.Tests.Unit/Business/FeatureFlagServiceTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/FeatureFlagServiceTests.cs
@@ -1,0 +1,30 @@
+using IntelligenceHub.Business.Implementations;
+using IntelligenceHub.Common.Config;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace IntelligenceHub.Tests.Unit.Business
+{
+    public class FeatureFlagServiceTests
+    {
+        [Fact]
+        public void UseAzureAISearch_ReturnsCurrentValue()
+        {
+            var options = new Mock<IOptionsMonitor<FeatureFlagSettings>>();
+            options.Setup(o => o.CurrentValue).Returns(new FeatureFlagSettings { UseAzureAISearch = true });
+            var service = new FeatureFlagService(options.Object);
+
+            Assert.True(service.UseAzureAISearch);
+        }
+
+        [Fact]
+        public void UseAzureAISearch_ReturnsFalse_WhenDisabled()
+        {
+            var options = new Mock<IOptionsMonitor<FeatureFlagSettings>>();
+            options.Setup(o => o.CurrentValue).Returns(new FeatureFlagSettings { UseAzureAISearch = false });
+            var service = new FeatureFlagService(options.Object);
+
+            Assert.False(service.UseAzureAISearch);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/Business/RateLimitServiceTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RateLimitServiceTests.cs
@@ -1,0 +1,43 @@
+using IntelligenceHub.Business.Implementations;
+using Microsoft.Extensions.Caching.Memory;
+using static IntelligenceHub.Common.GlobalVariables;
+
+namespace IntelligenceHub.Tests.Unit.Business
+{
+    public class RateLimitServiceTests
+    {
+        [Fact]
+        public void IsRequestAllowed_EnforcesFreeUserLimit()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var service = new RateLimitService(cache);
+            var key = Guid.NewGuid().ToString();
+
+            bool allowed = true;
+            for (int i = 0; i < FreeUserRateLimitRequests; i++)
+            {
+                allowed = service.IsRequestAllowed(key, false);
+                Assert.True(allowed);
+            }
+            allowed = service.IsRequestAllowed(key, false);
+            Assert.False(allowed);
+        }
+
+        [Fact]
+        public void IsRequestAllowed_EnforcesPaidUserLimit()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var service = new RateLimitService(cache);
+            var key = Guid.NewGuid().ToString();
+
+            bool allowed = true;
+            for (int i = 0; i < PaidUserRateLimitRequests; i++)
+            {
+                allowed = service.IsRequestAllowed(key, true);
+                Assert.True(allowed);
+            }
+            allowed = service.IsRequestAllowed(key, true);
+            Assert.False(allowed);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/Business/UsageServiceTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/UsageServiceTests.cs
@@ -1,0 +1,95 @@
+using IntelligenceHub.API.DTOs;
+using IntelligenceHub.Business.Implementations;
+using IntelligenceHub.Business.Interfaces;
+using IntelligenceHub.DAL.Interfaces;
+using IntelligenceHub.DAL.Models;
+using Moq;
+using static IntelligenceHub.Common.GlobalVariables;
+
+namespace IntelligenceHub.Tests.Unit.Business
+{
+    public class UsageServiceTests
+    {
+        [Fact]
+        public async Task ValidateAndIncrementUsageAsync_ReturnsFailure_WhenRateLimited()
+        {
+            var repo = new Mock<IUserRepository>();
+            var rate = new Mock<IRateLimitService>();
+            var user = new DbUser { Id = 1, AccessLevel = "Free" };
+            rate.Setup(r => r.IsRequestAllowed("1", false)).Returns(false);
+            var service = new UsageService(repo.Object, rate.Object);
+
+            var result = await service.ValidateAndIncrementUsageAsync(user);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(APIResponseStatusCodes.TooManyRequests, result.StatusCode);
+            repo.Verify(r => r.UpdateAsync(It.IsAny<DbUser>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ValidateAndIncrementUsageAsync_PaidUser_BypassesUpdates()
+        {
+            var repo = new Mock<IUserRepository>();
+            var rate = new Mock<IRateLimitService>();
+            var user = new DbUser { Id = 2, AccessLevel = "Paid" };
+            rate.Setup(r => r.IsRequestAllowed("2", true)).Returns(true);
+            var service = new UsageService(repo.Object, rate.Object);
+
+            var result = await service.ValidateAndIncrementUsageAsync(user);
+
+            Assert.True(result.IsSuccess);
+            repo.Verify(r => r.UpdateAsync(It.IsAny<DbUser>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ValidateAndIncrementUsageAsync_ResetsMonth_WhenNewMonth()
+        {
+            var repo = new Mock<IUserRepository>();
+            var rate = new Mock<IRateLimitService>();
+            var lastMonth = DateTime.UtcNow.AddMonths(-1);
+            var user = new DbUser { Id = 3, AccessLevel = "Free", RequestsThisMonth = 0, RequestMonthStart = lastMonth };
+            rate.Setup(r => r.IsRequestAllowed("3", false)).Returns(true);
+            repo.Setup(r => r.UpdateAsync(user)).ReturnsAsync(user);
+            var service = new UsageService(repo.Object, rate.Object);
+
+            await service.ValidateAndIncrementUsageAsync(user);
+
+            var expectedStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+            Assert.Equal(expectedStart, user.RequestMonthStart);
+            Assert.Equal(1, user.RequestsThisMonth);
+            repo.Verify(r => r.UpdateAsync(user), Times.Once);
+        }
+
+        [Fact]
+        public async Task ValidateAndIncrementUsageAsync_ReturnsFailure_WhenMonthlyLimitExceeded()
+        {
+            var repo = new Mock<IUserRepository>();
+            var rate = new Mock<IRateLimitService>();
+            var user = new DbUser { Id = 4, AccessLevel = "Free", RequestsThisMonth = FreeTierMonthlyLimit, RequestMonthStart = DateTime.UtcNow };
+            rate.Setup(r => r.IsRequestAllowed("4", false)).Returns(true);
+            var service = new UsageService(repo.Object, rate.Object);
+
+            var result = await service.ValidateAndIncrementUsageAsync(user);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(APIResponseStatusCodes.TooManyRequests, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task ValidateAndIncrementUsageAsync_Increments_WhenAllowed()
+        {
+            var repo = new Mock<IUserRepository>();
+            var rate = new Mock<IRateLimitService>();
+            var user = new DbUser { Id = 5, AccessLevel = "Free", RequestsThisMonth = 1, RequestMonthStart = DateTime.UtcNow };
+            rate.Setup(r => r.IsRequestAllowed("5", false)).Returns(true);
+            repo.Setup(r => r.UpdateAsync(user)).ReturnsAsync(user);
+            var service = new UsageService(repo.Object, rate.Object);
+
+            var result = await service.ValidateAndIncrementUsageAsync(user);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, user.RequestsThisMonth);
+            repo.Verify(r => r.UpdateAsync(user), Times.Once);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/Business/UserLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/UserLogicTests.cs
@@ -1,0 +1,48 @@
+using IntelligenceHub.Business.Implementations;
+using IntelligenceHub.DAL.Interfaces;
+using IntelligenceHub.DAL.Models;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace IntelligenceHub.Tests.Unit.Business
+{
+    public class UserLogicTests
+    {
+        [Fact]
+        public async Task GetUserBySubAsync_ReturnsRepositoryResult()
+        {
+            var config = new ConfigurationBuilder().Build();
+            var repo = new Mock<IUserRepository>();
+            var user = new DbUser();
+            repo.Setup(r => r.GetBySubAsync("sub")).ReturnsAsync(user);
+
+            var logic = new UserLogic(repo.Object, config);
+            var result = await logic.GetUserBySubAsync("sub");
+
+            Assert.Same(user, result);
+        }
+
+        [Fact]
+        public async Task GetUserByApiTokenAsync_HashesTokenAndQueriesRepository()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> { { "ApiKeyPepper", "pep" } })
+                .Build();
+            var repo = new Mock<IUserRepository>();
+            var user = new DbUser();
+            var token = "token";
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes("pep" + token);
+            var expectedHash = Convert.ToHexString(sha.ComputeHash(bytes));
+            repo.Setup(r => r.GetByApiTokenAsync(expectedHash)).ReturnsAsync(user);
+
+            var logic = new UserLogic(repo.Object, configuration);
+            var result = await logic.GetUserByApiTokenAsync(token);
+
+            Assert.Same(user, result);
+            repo.Verify(r => r.GetByApiTokenAsync(expectedHash), Times.Once);
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/Factories/AGIClientFactoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/Factories/AGIClientFactoryTests.cs
@@ -1,0 +1,71 @@
+using IntelligenceHub.Business.Factories;
+using IntelligenceHub.Client.Implementations;
+using Moq;
+using System.Runtime.Serialization;
+using static IntelligenceHub.Common.GlobalVariables;
+
+namespace IntelligenceHub.Tests.Unit.Factories
+{
+    public class AGIClientFactoryTests
+    {
+        [Fact]
+        public void GetClient_ReturnsOpenAIClient()
+        {
+            var open = (OpenAIClient)FormatterServices.GetUninitializedObject(typeof(OpenAIClient));
+            var azure = (AzureAIClient)FormatterServices.GetUninitializedObject(typeof(AzureAIClient));
+            var anthropic = (AnthropicAIClient)FormatterServices.GetUninitializedObject(typeof(AnthropicAIClient));
+            var provider = new Mock<IServiceProvider>();
+            provider.Setup(p => p.GetService(typeof(OpenAIClient))).Returns(open);
+            provider.Setup(p => p.GetService(typeof(AzureAIClient))).Returns(azure);
+            provider.Setup(p => p.GetService(typeof(AnthropicAIClient))).Returns(anthropic);
+
+            var factory = new AGIClientFactory(provider.Object);
+            var result = factory.GetClient(AGIServiceHost.OpenAI);
+
+            Assert.Same(open, result);
+        }
+
+        [Fact]
+        public void GetClient_ReturnsAzureClient()
+        {
+            var open = (OpenAIClient)FormatterServices.GetUninitializedObject(typeof(OpenAIClient));
+            var azure = (AzureAIClient)FormatterServices.GetUninitializedObject(typeof(AzureAIClient));
+            var anthropic = (AnthropicAIClient)FormatterServices.GetUninitializedObject(typeof(AnthropicAIClient));
+            var provider = new Mock<IServiceProvider>();
+            provider.Setup(p => p.GetService(typeof(OpenAIClient))).Returns(open);
+            provider.Setup(p => p.GetService(typeof(AzureAIClient))).Returns(azure);
+            provider.Setup(p => p.GetService(typeof(AnthropicAIClient))).Returns(anthropic);
+
+            var factory = new AGIClientFactory(provider.Object);
+            var result = factory.GetClient(AGIServiceHost.Azure);
+
+            Assert.Same(azure, result);
+        }
+
+        [Fact]
+        public void GetClient_ReturnsAnthropicClient()
+        {
+            var open = (OpenAIClient)FormatterServices.GetUninitializedObject(typeof(OpenAIClient));
+            var azure = (AzureAIClient)FormatterServices.GetUninitializedObject(typeof(AzureAIClient));
+            var anthropic = (AnthropicAIClient)FormatterServices.GetUninitializedObject(typeof(AnthropicAIClient));
+            var provider = new Mock<IServiceProvider>();
+            provider.Setup(p => p.GetService(typeof(OpenAIClient))).Returns(open);
+            provider.Setup(p => p.GetService(typeof(AzureAIClient))).Returns(azure);
+            provider.Setup(p => p.GetService(typeof(AnthropicAIClient))).Returns(anthropic);
+
+            var factory = new AGIClientFactory(provider.Object);
+            var result = factory.GetClient(AGIServiceHost.Anthropic);
+
+            Assert.Same(anthropic, result);
+        }
+
+        [Fact]
+        public void GetClient_InvalidHost_Throws()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var factory = new AGIClientFactory(provider.Object);
+
+            Assert.Throws<ArgumentException>(() => factory.GetClient(null));
+        }
+    }
+}

--- a/IntelligenceHub.Tests.Unit/Factories/RagClientFactoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/Factories/RagClientFactoryTests.cs
@@ -1,0 +1,51 @@
+using IntelligenceHub.Business.Factories;
+using IntelligenceHub.Client.Implementations;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Runtime.Serialization;
+using static IntelligenceHub.Common.GlobalVariables;
+
+namespace IntelligenceHub.Tests.Unit.Factories
+{
+    public class RagClientFactoryTests
+    {
+        [Fact]
+        public void GetClient_ReturnsWeaviateClient()
+        {
+            var weaviate = (WeaviateSearchServiceClient)FormatterServices.GetUninitializedObject(typeof(WeaviateSearchServiceClient));
+            var azure = (AzureAISearchServiceClient)FormatterServices.GetUninitializedObject(typeof(AzureAISearchServiceClient));
+            var provider = new Mock<IServiceProvider>();
+            provider.Setup(p => p.GetService(typeof(WeaviateSearchServiceClient))).Returns(weaviate);
+            provider.Setup(p => p.GetService(typeof(AzureAISearchServiceClient))).Returns(azure);
+
+            var factory = new RagClientFactory(provider.Object);
+            var result = factory.GetClient(RagServiceHost.Weaviate);
+
+            Assert.Same(weaviate, result);
+        }
+
+        [Fact]
+        public void GetClient_ReturnsAzureClient()
+        {
+            var weaviate = (WeaviateSearchServiceClient)FormatterServices.GetUninitializedObject(typeof(WeaviateSearchServiceClient));
+            var azure = (AzureAISearchServiceClient)FormatterServices.GetUninitializedObject(typeof(AzureAISearchServiceClient));
+            var provider = new Mock<IServiceProvider>();
+            provider.Setup(p => p.GetService(typeof(WeaviateSearchServiceClient))).Returns(weaviate);
+            provider.Setup(p => p.GetService(typeof(AzureAISearchServiceClient))).Returns(azure);
+
+            var factory = new RagClientFactory(provider.Object);
+            var result = factory.GetClient(RagServiceHost.Azure);
+
+            Assert.Same(azure, result);
+        }
+
+        [Fact]
+        public void GetClient_InvalidHost_Throws()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var factory = new RagClientFactory(provider.Object);
+
+            Assert.Throws<ArgumentException>(() => factory.GetClient(null));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing unit tests for UserLogic and UsageService
- cover RateLimitService and FeatureFlagService functionality
- add tests for RagClientFactory and AGIClientFactory

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687afd10ba44832e9ab69947a0bd29bc