### PR TITLE
Fix AGIClientFactory Anthropic client instantiation

### DIFF
--- a/IntelligenceHub.Business/Factories/AGIClientFactory.cs
+++ b/IntelligenceHub.Business/Factories/AGIClientFactory.cs
@@ -32,13 +32,18 @@ namespace IntelligenceHub.Business.Factories
         /// <exception cref="ArgumentException">Thrown if the host does not match any existing client.</exception>
         public IAGIClient GetClient(AGIServiceHost? host)
         {
-            if (host == AGIServiceHost.OpenAI || host == AGIServiceHost.Azure || host == AGIServiceHost.Anthropic)
+            if (host == AGIServiceHost.OpenAI || host == AGIServiceHost.Azure)
             {
                 var options = _serviceProvider.GetRequiredService<IOptionsMonitor<AGIClientSettings>>();
                 var httpFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
                 return new AzureAIClient(options, httpFactory, host.Value);
             }
-            else if (host == AGIServiceHost.Anthropic) return _serviceProvider.GetRequiredService<AnthropicAIClient>();
+            else if (host == AGIServiceHost.Anthropic)
+            {
+                var options = _serviceProvider.GetRequiredService<IOptionsMonitor<AGIClientSettings>>();
+                var httpFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
+                return new AnthropicAIClient(options, httpFactory);
+            }
 
             throw new ArgumentException($"Invalid service name: {host}");
         }

--- a/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
@@ -8,6 +8,7 @@ using IntelligenceHub.Client.Interfaces;
 using IntelligenceHub.Client.Implementations;
 using IntelligenceHub.Common.Config;
 using IntelligenceHub.DAL;
+using IntelligenceHub.DAL.Tenant;
 using IntelligenceHub.DAL.Interfaces;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,9 +63,6 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexName = "testIndex";
-            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
-            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
-            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
             var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
             var dbIndexMetadata = new DbIndexMetadata { Name = fullName, GenerationHost = AGIServiceHost.Azure.ToString() };
             _mockValidationHandler.Setup(repo => repo.IsValidIndexName(indexName)).Returns(true);
@@ -770,6 +768,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexName = "testIndex";
+            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
             var count = 10;
             var page = 1;
             var dbDocuments = new List<DbIndexDocument>
@@ -815,6 +814,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexName = "testIndex";
+            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
             var count = 10;
             var page = 1;
             var dbDocuments = new List<DbIndexDocument>();
@@ -836,6 +836,7 @@ namespace IntelligenceHub.Tests.Unit.Business
         {
             // Arrange
             var indexName = "testIndex";
+            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
             var count = 10;
             var page = 1;
 

--- a/IntelligenceHub.Tests.Unit/Client/AzureAIClientTests.cs
+++ b/IntelligenceHub.Tests.Unit/Client/AzureAIClientTests.cs
@@ -1,6 +1,7 @@
 using IntelligenceHub.Client.Implementations;
 using IntelligenceHub.Common.Config;
 using IntelligenceHub.Common;
+using static IntelligenceHub.Common.GlobalVariables;
 using Microsoft.Extensions.Options;
 using Moq;
 using System.Reflection;
@@ -26,7 +27,7 @@ namespace IntelligenceHub.Tests.Unit.Client
             var factory = new Mock<IHttpClientFactory>();
             factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
-            return new AzureAIClient(options.Object, factory.Object);
+            return new AzureAIClient(options.Object, factory.Object, AGIServiceHost.Azure);
         }
 
         [Fact]

--- a/IntelligenceHub.Tests.Unit/Factories/AGIClientFactoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/Factories/AGIClientFactoryTests.cs
@@ -63,13 +63,13 @@ namespace IntelligenceHub.Tests.Unit.Factories
         }
 
         [Fact]
-        public void GetClient_ReturnsAzureClient_ForAnthropic()
+        public void GetClient_ReturnsAnthropicClient()
         {
             var provider = CreateProvider();
             var factory = new AGIClientFactory(provider);
             var result = factory.GetClient(AGIServiceHost.Anthropic);
 
-            Assert.IsType<AzureAIClient>(result);
+            Assert.IsType<AnthropicAIClient>(result);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- exclude Anthropic host from default OpenAI/Azure path
- properly build AnthropicAIClient in factory
- update tests for Anthropic host
- fix failing unit build by adjusting AzureAIClient test and RagLogic tests

## Testing
- `dotnet test IntelligenceHub.Tests.Unit/IntelligenceHub.Tests.Unit.csproj --verbosity minimal` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d60885184832eb7d214e8c5a7220c