### PR TITLE
Fix env var list in script

### DIFF
--- a/infrastructure/env_setup.py
+++ b/infrastructure/env_setup.py
@@ -58,8 +58,8 @@ required_env_vars = [
     "Settings_DbConnectionString",
     "AuthSettings_Domain",
     "AuthSettings_Audience",
-    "AuthSettings_BasicUsername"
-    "AuthSettings_BasicPassword"
+    "AuthSettings_BasicUsername",
+    "AuthSettings_BasicPassword",
     "AuthSettings_DefaultClientId",
     "AuthSettings_DefaultClientSecret",
     "AuthSettings_AdminClientId",


### PR DESCRIPTION
## Summary
- fix comma in `infrastructure/env_setup.py` so `AuthSettings_BasicUsername` and `AuthSettings_BasicPassword` are separate list entries
- confirm the script can run with both variables

## Testing
- `python infrastructure/env_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_687d60849e94832e849ac4db1e727e2c