### PR TITLE
Add custom JWT token generation

### DIFF
--- a/IntelligenceHub.Business/Implementations/AuthLogic.cs
+++ b/IntelligenceHub.Business/Implementations/AuthLogic.cs
@@ -1,6 +1,6 @@
 ﻿using IntelligenceHub.API.DTOs.Auth;
 using IntelligenceHub.Business.Interfaces;
-using IntelligenceHub.Client.Interfaces;
+using IntelligenceHub.DAL.Models;
 using System.Threading.Tasks;
 
 namespace IntelligenceHub.Business.Implementations
@@ -10,33 +10,33 @@ namespace IntelligenceHub.Business.Implementations
     /// </summary>
     public class AuthLogic : IAuthLogic
     {
-        private readonly IAIAuth0Client _auth0Client;
+        private readonly IJwtService _jwtService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthLogic"/> class.
         /// </summary>
-        /// <param name="auth0Client">The Auth0 client used for authentication requests.</param>
-        public AuthLogic(IAIAuth0Client auth0Client)
+        /// <param name="jwtService">Service used to create JWTs.</param>
+        public AuthLogic(IJwtService jwtService)
         {
-            _auth0Client = auth0Client;
+            _jwtService = jwtService;
         }
 
         /// <summary>
         /// Gets the default authentication token.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation. The task result contains the Auth0 response.</returns>
-        public async Task<Auth0Response?> GetDefaultAuthToken()
+        public Task<Auth0Response?> GetDefaultAuthToken(DbUser user)
         {
-            return await _auth0Client.RequestAuthToken();
+            return Task.FromResult<Auth0Response?>(_jwtService.GenerateToken(user, false));
         }
 
         /// <summary>
         /// Gets the admin authentication token.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation. The task result contains the Auth0 response.</returns>
-        public async Task<Auth0Response?> GetAdminAuthToken()
+        public Task<Auth0Response?> GetAdminAuthToken(DbUser user)
         {
-            return await _auth0Client.RequestElevatedAuthToken();
+            return Task.FromResult<Auth0Response?>(_jwtService.GenerateToken(user, true));
         }
     }
 }

--- a/IntelligenceHub.Business/Implementations/JwtService.cs
+++ b/IntelligenceHub.Business/Implementations/JwtService.cs
@@ -1,0 +1,62 @@
+using IntelligenceHub.API.DTOs.Auth;
+using IntelligenceHub.Business.Interfaces;
+using IntelligenceHub.Common.Config;
+using IntelligenceHub.DAL.Models;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace IntelligenceHub.Business.Implementations
+{
+    /// <summary>
+    /// Service that generates JWT tokens for the API.
+    /// </summary>
+    public class JwtService : IJwtService
+    {
+        private readonly AuthSettings _settings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtService"/> class.
+        /// </summary>
+        public JwtService(AuthSettings settings)
+        {
+            _settings = settings;
+        }
+
+        /// <inheritdoc/>
+        public Auth0Response GenerateToken(DbUser user, bool isAdmin)
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.JwtSecret));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var claims = new List<Claim>
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, user.Sub),
+                new Claim("tenant_id", user.TenantId.ToString())
+            };
+
+            if (isAdmin)
+            {
+                claims.Add(new Claim("roles", "admin"));
+            }
+
+            var token = new JwtSecurityToken(
+                issuer: _settings.Domain,
+                audience: _settings.Audience,
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: creds);
+
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.WriteToken(token);
+
+            return new Auth0Response
+            {
+                AccessToken = jwt,
+                ExpiresIn = (int)TimeSpan.FromHours(1).TotalSeconds,
+                TokenType = "Bearer"
+            };
+        }
+    }
+}

--- a/IntelligenceHub.Business/Interfaces/IAuthLogic.cs
+++ b/IntelligenceHub.Business/Interfaces/IAuthLogic.cs
@@ -1,4 +1,5 @@
 ﻿using IntelligenceHub.API.DTOs.Auth;
+using IntelligenceHub.DAL.Models;
 using System.Threading.Tasks;
 
 namespace IntelligenceHub.Business.Interfaces
@@ -12,12 +13,12 @@ namespace IntelligenceHub.Business.Interfaces
         /// Gets the default authentication token.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation. The task result contains the Auth0 response.</returns>
-        Task<Auth0Response?> GetDefaultAuthToken();
+        Task<Auth0Response?> GetDefaultAuthToken(DbUser user);
 
         /// <summary>
         /// Gets the admin authentication token.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation. The task result contains the Auth0 response.</returns>
-        Task<Auth0Response?> GetAdminAuthToken();
+        Task<Auth0Response?> GetAdminAuthToken(DbUser user);
     }
 }

--- a/IntelligenceHub.Business/Interfaces/IJwtService.cs
+++ b/IntelligenceHub.Business/Interfaces/IJwtService.cs
@@ -1,0 +1,16 @@
+namespace IntelligenceHub.Business.Interfaces
+{
+    using IntelligenceHub.API.DTOs.Auth;
+    using IntelligenceHub.DAL.Models;
+
+    /// <summary>
+    /// Generates JWT tokens for API authentication.
+    /// </summary>
+    public interface IJwtService
+    {
+        /// <summary>
+        /// Creates a JWT for the specified user.
+        /// </summary>
+        Auth0Response GenerateToken(DbUser user, bool isAdmin);
+    }
+}

--- a/IntelligenceHub.Common/Config/AuthSettings.cs
+++ b/IntelligenceHub.Common/Config/AuthSettings.cs
@@ -44,6 +44,11 @@ namespace IntelligenceHub.Common.Config
         /// Gets or sets the administrator client secret.
         /// </summary>
         public string AdminClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the secret used to sign JWTs.
+        /// </summary>
+        public string JwtSecret { get; set; }
     }
 }
 

--- a/IntelligenceHub.Controllers/AuthController.cs
+++ b/IntelligenceHub.Controllers/AuthController.cs
@@ -46,7 +46,7 @@ namespace IntelligenceHub.API.Controllers
                 var user = await _userLogic.GetUserByApiTokenAsync(apiKey);
                 if (user is null) return Unauthorized();
 
-                var token = await _authLogic.GetAdminAuthToken();
+                var token = await _authLogic.GetAdminAuthToken(user);
                 return token is null ? Unauthorized() : Ok(token);
             }
             catch
@@ -72,7 +72,7 @@ namespace IntelligenceHub.API.Controllers
                 var user = await _userLogic.GetUserByApiTokenAsync(apiKey);
                 if (user is null) return Unauthorized();
 
-                var token = await _authLogic.GetDefaultAuthToken();
+                var token = await _authLogic.GetDefaultAuthToken(user);
                 return token is null ? Unauthorized() : Ok(token);
             }
             catch

--- a/IntelligenceHub.Host/Program.cs
+++ b/IntelligenceHub.Host/Program.cs
@@ -19,6 +19,7 @@ using Polly;
 using Polly.Extensions.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text;
 using static IntelligenceHub.Common.GlobalVariables;
 using IntelligenceHub.Business.Factories;
 using IntelligenceHub.Host.Swagger;
@@ -102,7 +103,7 @@ namespace IntelligenceHub.Host
             builder.Services.AddSingleton<IToolClient, ToolClient>();
             builder.Services.AddSingleton<AzureAISearchServiceClient>();
             builder.Services.AddSingleton<WeaviateSearchServiceClient>();
-            builder.Services.AddSingleton<IAIAuth0Client, Auth0Client>();
+            builder.Services.AddSingleton<IJwtService, JwtService>();
             builder.Services.AddScoped<ITenantProvider, TenantProvider>();
 
             // Repositories
@@ -230,13 +231,16 @@ namespace IntelligenceHub.Host
                 options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
             }).AddJwtBearer(options =>
             {
-                options.Authority = authSettings.Domain;
-                options.Audience = authSettings.Audience;
-
-                // Specify the Role Claim Type if necessary
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
-                    RoleClaimType = "roles"
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(authSettings.JwtSecret)),
+                    ValidateIssuer = true,
+                    ValidIssuer = authSettings.Domain,
+                    ValidateAudience = true,
+                    ValidAudience = authSettings.Audience,
+                    RoleClaimType = "roles",
+                    ClockSkew = TimeSpan.Zero
                 };
             });
 

--- a/IntelligenceHub.Host/appsettings.Template.json
+++ b/IntelligenceHub.Host/appsettings.Template.json
@@ -38,7 +38,8 @@
     "AdminClientId": "__AuthSettings_AdminClientId__",
     "AdminClientSecret": "__AuthSettings_AdminClientSecret__",
     "Domain": "__AuthSettings_Domain__",
-    "Audience": "__AuthSettings_Audience__"
+    "Audience": "__AuthSettings_Audience__",
+    "JwtSecret": "__AuthSettings_JwtSecret__"
   },
   "AppInsightSettings": {
     "ConnectionString": "__AppInsightSettings_ConnectionString__"

--- a/IntelligenceHub.Tests.Unit/Controllers/AuthControllerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/AuthControllerTests.cs
@@ -34,8 +34,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         {
             // Arrange
             var token = new Auth0Response { AccessToken = "admin", ExpiresIn = 3600, TokenType = "Bearer" };
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetAdminAuthToken()).ReturnsAsync(token);
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetAdminAuthToken(user)).ReturnsAsync(token);
 
             // Act
             var result = await _sut.GetAdminToken(ValidKey);
@@ -63,8 +64,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task GetAdminToken_ReturnsUnauthorized_WhenTokenNull()
         {
             // Arrange
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetAdminAuthToken()).ReturnsAsync((Auth0Response)null);
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetAdminAuthToken(user)).ReturnsAsync((Auth0Response)null);
 
             // Act
             var result = await _sut.GetAdminToken(ValidKey);
@@ -77,8 +79,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task GetAdminToken_ReturnsInternalServerError_OnException()
         {
             // Arrange
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetAdminAuthToken()).ThrowsAsync(new Exception("boom"));
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetAdminAuthToken(user)).ThrowsAsync(new Exception("boom"));
 
             // Act
             var result = await _sut.GetAdminToken(ValidKey);
@@ -96,8 +99,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         {
             // Arrange
             var token = new Auth0Response { AccessToken = "default", ExpiresIn = 3600, TokenType = "Bearer" };
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetDefaultAuthToken()).ReturnsAsync(token);
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetDefaultAuthToken(user)).ReturnsAsync(token);
 
             // Act
             var result = await _sut.GetDefaultToken(ValidKey);
@@ -125,8 +129,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task GetDefaultToken_ReturnsUnauthorized_WhenTokenNull()
         {
             // Arrange
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetDefaultAuthToken()).ReturnsAsync((Auth0Response)null);
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetDefaultAuthToken(user)).ReturnsAsync((Auth0Response)null);
 
             // Act
             var result = await _sut.GetDefaultToken(ValidKey);
@@ -139,8 +144,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task GetDefaultToken_ReturnsInternalServerError_OnException()
         {
             // Arrange
-            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(new DbUser());
-            _authLogicMock.Setup(x => x.GetDefaultAuthToken()).ThrowsAsync(new Exception());
+            var user = new DbUser();
+            _userLogicMock.Setup(x => x.GetUserByApiTokenAsync(ValidKey)).ReturnsAsync(user);
+            _authLogicMock.Setup(x => x.GetDefaultAuthToken(user)).ThrowsAsync(new Exception());
 
             // Act
             var result = await _sut.GetDefaultToken(ValidKey);

--- a/infrastructure/env_setup.py
+++ b/infrastructure/env_setup.py
@@ -64,6 +64,7 @@ required_env_vars = [
     "AuthSettings_DefaultClientSecret",
     "AuthSettings_AdminClientId",
     "AuthSettings_AdminClientSecret",
+    "AuthSettings_JwtSecret",
     "AppInsightSettings_ConnectionString",
     "AGIClientSettings_AzureOpenAIServices_0_Endpoint",
     "AGIClientSettings_AzureOpenAIServices_0_Key",


### PR DESCRIPTION
## Summary
- support managed service JWT auth
- introduce `JwtService` for signing tokens
- update `AuthLogic` to use `JwtService`
- add signing secret to auth settings and config templates
- wire new service in host and update auth handler
- revise unit tests for updated logic

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb3c91c1c832e87b631787a852015