### PR TITLE
Use tenant_id claim for tenant context

### DIFF
--- a/IntelligenceHub.Business/Implementations/UserLogic.cs
+++ b/IntelligenceHub.Business/Implementations/UserLogic.cs
@@ -2,6 +2,7 @@
 using IntelligenceHub.DAL.Interfaces;
 using IntelligenceHub.DAL.Models;
 using Microsoft.Extensions.Configuration;
+using System;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -32,6 +33,12 @@ namespace IntelligenceHub.Business.Implementations
         {
             var hash = HashApiKey(apiToken);
             return await _userRepository.GetByApiTokenAsync(hash);
+        }
+
+        /// <inheritdoc/>
+        public async Task<DbUser?> GetUserByTenantIdAsync(Guid tenantId)
+        {
+            return await _userRepository.GetByTenantIdAsync(tenantId);
         }
 
         /// <summary>

--- a/IntelligenceHub.Business/Interfaces/IUserLogic.cs
+++ b/IntelligenceHub.Business/Interfaces/IUserLogic.cs
@@ -16,5 +16,10 @@ namespace IntelligenceHub.Business.Interfaces
         /// Gets a user by the stored API token.
         /// </summary>
         Task<DbUser?> GetUserByApiTokenAsync(string apiToken);
+
+        /// <summary>
+        /// Gets a user by tenant identifier.
+        /// </summary>
+        Task<DbUser?> GetUserByTenantIdAsync(Guid tenantId);
     }
 }

--- a/IntelligenceHub.Common/GlobalVariables.cs
+++ b/IntelligenceHub.Common/GlobalVariables.cs
@@ -193,6 +193,11 @@
         public const string ElevatedAuthPolicy = "AdminPolicy";
 
         /// <summary>
+        /// The claim type containing the tenant identifier.
+        /// </summary>
+        public const string TenantIdClaim = "tenant_id";
+
+        /// <summary>
         /// The system message for RAG requests.
         /// </summary>
         public const string RagMetadataGenSystemMessage =

--- a/IntelligenceHub.DAL/Implementations/UserRepository.cs
+++ b/IntelligenceHub.DAL/Implementations/UserRepository.cs
@@ -35,6 +35,12 @@ namespace IntelligenceHub.DAL.Implementations
         }
 
         /// <inheritdoc/>
+        public async Task<DbUser?> GetByTenantIdAsync(Guid tenantId)
+        {
+            return await _dbSet.FirstOrDefaultAsync(u => u.TenantId == tenantId);
+        }
+
+        /// <inheritdoc/>
         public async Task<DbUser> UpdateAsync(DbUser user)
         {
             _dbSet.Attach(user);

--- a/IntelligenceHub.DAL/Interfaces/IUserRepository.cs
+++ b/IntelligenceHub.DAL/Interfaces/IUserRepository.cs
@@ -22,6 +22,13 @@ namespace IntelligenceHub.DAL.Interfaces
         Task<DbUser?> GetByApiTokenAsync(string apiToken);
 
         /// <summary>
+        /// Retrieves a user entity by tenant identifier.
+        /// </summary>
+        /// <param name="tenantId">Tenant identifier associated with the user.</param>
+        /// <returns>The user if found; otherwise null.</returns>
+        Task<DbUser?> GetByTenantIdAsync(Guid tenantId);
+
+        /// <summary>
         /// Updates a user entity.
         /// </summary>
         Task<DbUser> UpdateAsync(DbUser user);

--- a/IntelligenceHub.Host/Auth/BasicAuthenticationHandler.cs
+++ b/IntelligenceHub.Host/Auth/BasicAuthenticationHandler.cs
@@ -7,6 +7,8 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using IntelligenceHub.Common.Config;
+using static IntelligenceHub.Common.GlobalVariables;
+using System;
 
 /// <summary>
 /// Handles basic authentication for the application.
@@ -57,6 +59,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
                 var claims = new[] {
                     new Claim(ClaimTypes.NameIdentifier, username),
                     new Claim(ClaimTypes.Name, username),
+                    new Claim(TenantIdClaim, Guid.Empty.ToString()),
                     new Claim("scope", "all:admin"), // Add required claim for elevated policy
                     new Claim("scope", "all:user")
                 };

--- a/IntelligenceHub.Tests.Unit/Business/UserLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/UserLogicTests.cs
@@ -5,21 +5,23 @@ using Microsoft.Extensions.Configuration;
 using Moq;
 using System.Security.Cryptography;
 using System.Text;
+using System;
 
 namespace IntelligenceHub.Tests.Unit.Business
 {
     public class UserLogicTests
     {
         [Fact]
-        public async Task GetUserBySubAsync_ReturnsRepositoryResult()
+        public async Task GetUserByTenantIdAsync_ReturnsRepositoryResult()
         {
             var config = new ConfigurationBuilder().Build();
             var repo = new Mock<IUserRepository>();
             var user = new DbUser();
-            repo.Setup(r => r.GetBySubAsync("sub")).ReturnsAsync(user);
+            var tenantId = Guid.NewGuid();
+            repo.Setup(r => r.GetByTenantIdAsync(tenantId)).ReturnsAsync(user);
 
             var logic = new UserLogic(repo.Object, config);
-            var result = await logic.GetUserBySubAsync("sub");
+            var result = await logic.GetUserByTenantIdAsync(tenantId);
 
             Assert.Same(user, result);
         }

--- a/IntelligenceHub.Tests.Unit/Controllers/MessageHistoryControllerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/MessageHistoryControllerTests.cs
@@ -5,6 +5,7 @@ using IntelligenceHub.DAL.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System;
 using Moq;
 using static IntelligenceHub.Common.GlobalVariables;
 using IntelligenceHub.DAL.Tenant;
@@ -28,8 +29,8 @@ namespace IntelligenceHub.Tests.Unit.Controllers
             _mockHttpContext = new Mock<HttpContext>();
 
             var testUser = new DbUser { Id = 1, Sub = "test-sub", TenantId = Guid.NewGuid(), ApiToken = "token" };
-            _mockUserLogic.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(testUser);
-            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "test-sub") }));
+            _mockUserLogic.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(testUser);
+            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(TenantIdClaim, testUser.TenantId.ToString()) }));
             _mockHttpContext.Setup(c => c.User).Returns(claims);
 
             _controller = new MessageHistoryController(_mockMessageHistoryLogic.Object, _mockUserLogic.Object, _mockTenantProvider.Object);
@@ -193,7 +194,7 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task GetConversation_ReturnsStatus500_WhenTenantResolutionFails()
         {
             // Arrange
-            _mockUserLogic.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync((DbUser?)null);
+            _mockUserLogic.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync((DbUser?)null);
 
             // Act
             var result = await _controller.GetConversation(Guid.NewGuid(), 1, 1);
@@ -207,7 +208,7 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task UpsertConversationData_ReturnsStatus500_WhenTenantResolutionFails()
         {
             // Arrange
-            _mockUserLogic.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync((DbUser?)null);
+            _mockUserLogic.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync((DbUser?)null);
 
             // Act
             var result = await _controller.UpsertConversationData(Guid.NewGuid(), new List<Message>{ new Message() });

--- a/IntelligenceHub.Tests.Unit/Controllers/ProfileControllerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/ProfileControllerTests.cs
@@ -6,6 +6,7 @@ using IntelligenceHub.API.DTOs;
 using IntelligenceHub.DAL.Models;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System;
 using static IntelligenceHub.Common.GlobalVariables;
 using IntelligenceHub.DAL.Tenant;
 
@@ -27,8 +28,8 @@ namespace IntelligenceHub.Tests.Unit.Controllers
             _mockHttpContext = new Mock<HttpContext>();
 
             var testUser = new DbUser { Id = 1, Sub = "test-sub", TenantId = Guid.NewGuid(), ApiToken = "token" };
-            _mockUserLogic.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(testUser);
-            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "test-sub") }));
+            _mockUserLogic.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(testUser);
+            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(TenantIdClaim, testUser.TenantId.ToString()) }));
             _mockHttpContext.Setup(c => c.User).Returns(claims);
 
             _controller = new ProfileController(_mockProfileLogic.Object, _mockUserLogic.Object, _mockTenantProvider.Object);
@@ -192,7 +193,7 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         [Fact]
         public async Task GetProfile_Returns500_WhenTenantResolutionFails()
         {
-            _mockUserLogic.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync((DbUser?)null);
+            _mockUserLogic.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync((DbUser?)null);
 
             var result = await _controller.GetProfile("name");
 

--- a/IntelligenceHub.Tests.Unit/Controllers/TenantControllerBaseTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/TenantControllerBaseTests.cs
@@ -4,6 +4,7 @@ using IntelligenceHub.DAL.Models;
 using IntelligenceHub.Business.Interfaces;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System;
 using Moq;
 using Xunit;
 using IntelligenceHub.DAL.Tenant;
@@ -43,9 +44,10 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         public async Task SetUserTenantContextAsync_ReturnsFailure_WhenUserNotFound()
         {
             var ctx = new DefaultHttpContext();
-            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "sub") }));
+            var tenantId = Guid.NewGuid();
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(TenantIdClaim, tenantId.ToString()) }));
             _controller.ControllerContext.HttpContext = ctx;
-            _userLogic.Setup(u => u.GetUserBySubAsync("sub")).ReturnsAsync((DbUser?)null);
+            _userLogic.Setup(u => u.GetUserByTenantIdAsync(tenantId)).ReturnsAsync((DbUser?)null);
 
             var result = await _controller.Invoke();
 
@@ -58,9 +60,9 @@ namespace IntelligenceHub.Tests.Unit.Controllers
         {
             var user = new DbUser { TenantId = Guid.NewGuid(), Sub = "sub" };
             var ctx = new DefaultHttpContext();
-            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "sub") }));
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(TenantIdClaim, user.TenantId.ToString()) }));
             _controller.ControllerContext.HttpContext = ctx;
-            _userLogic.Setup(u => u.GetUserBySubAsync("sub")).ReturnsAsync(user);
+            _userLogic.Setup(u => u.GetUserByTenantIdAsync(user.TenantId)).ReturnsAsync(user);
 
             var result = await _controller.Invoke();
 

--- a/IntelligenceHub.Tests.Unit/Controllers/ToolControllerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/ToolControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System;
 using Moq;
 using static IntelligenceHub.Common.GlobalVariables;
 using IntelligenceHub.DAL.Tenant;
@@ -31,8 +32,8 @@ namespace IntelligenceHub.Tests.Unit.Controllers
             _httpContext = new Mock<HttpContext>();
 
             var testUser = new DbUser { Id = 1, Sub = "test-sub", TenantId = Guid.NewGuid(), ApiToken = "token" };
-            _userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(testUser);
-            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "test-sub") }));
+            _userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(testUser);
+            var claims = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(TenantIdClaim, testUser.TenantId.ToString()) }));
             _httpContext.Setup(c => c.User).Returns(claims);
 
             _controller = new ToolController(_profileLogicMock.Object, _userLogicMock.Object, _tenantProvider.Object);

--- a/IntelligenceHub.Tests.Unit/Hubs/ChatHubTests.cs
+++ b/IntelligenceHub.Tests.Unit/Hubs/ChatHubTests.cs
@@ -9,6 +9,7 @@ using IntelligenceHub.DAL.Models;
 using IntelligenceHub.DAL.Tenant;
 using IntelligenceHub.Hubs;
 using System.Security.Claims;
+using System;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 using Xunit;
@@ -29,7 +30,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clients = new Mock<IHubCallerClients>();
             clients.Setup(c => c.Caller).Returns(clientProxy.Object);
             var context = new Mock<HubCallerContext>();
-            claimsPrincipal ??= new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "sub") }));
+            claimsPrincipal ??= new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(GlobalVariables.TenantIdClaim, Guid.NewGuid().ToString()) }));
             context.Setup(c => c.User).Returns(claimsPrincipal);
 
             var hub = new ChatHub(completionMock.Object, validationMock.Object, userLogicMock.Object, tenantProviderMock.Object, usageMock.Object)
@@ -61,7 +62,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             const string error = "Invalid";
@@ -84,7 +85,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             var chunk = APIResponseWrapper<CompletionStreamChunk>.Success(new CompletionStreamChunk { CompletionUpdate = "hi" });
@@ -106,7 +107,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             const string msg = "missing";
@@ -130,7 +131,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             completionMock.Setup(c => c.StreamCompletion(request)).Throws(new System.Exception());
@@ -153,7 +154,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>()))
                      .ReturnsAsync(APIResponseWrapper<bool>.Failure("limit", GlobalVariables.APIResponseStatusCodes.TooManyRequests));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
 
@@ -173,7 +174,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync((DbUser?)null);
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync((DbUser?)null);
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
 
@@ -201,7 +202,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
 
             var expected = $"Response Status: {500}. Error message: {GlobalVariables.DefaultExceptionMessage}";
             clientProxy.Verify(p => p.SendCoreAsync("broadcastMessage", It.Is<object[]>(o => (string)o[0] == expected), default), Times.Once);
-            userLogicMock.Verify(u => u.GetUserBySubAsync(It.IsAny<string>()), Times.Never);
+            userLogicMock.Verify(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>()), Times.Never);
         }
 
         [Fact]
@@ -215,7 +216,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             const string msg = "limit";
@@ -239,7 +240,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
             var clientProxy = new Mock<ISingleClientProxy>();
             tenantProviderMock.SetupAllProperties();
             usageMock.Setup(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>())).ReturnsAsync(APIResponseWrapper<bool>.Success(true));
-            userLogicMock.Setup(u => u.GetUserBySubAsync(It.IsAny<string>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
+            userLogicMock.Setup(u => u.GetUserByTenantIdAsync(It.IsAny<Guid>())).ReturnsAsync(new DbUser { TenantId = Guid.NewGuid() });
             var hub = CreateHub(completionMock, validationMock, userLogicMock, tenantProviderMock, usageMock, clientProxy);
             var request = new CompletionRequest();
             const string msg = "error";


### PR DESCRIPTION
## Summary
- add `TenantIdClaim` constant
- resolve tenant context from `tenant_id` instead of `sub`
- update BasicAuth to emit this claim
- fetch users by tenant id via new repository and logic methods
- update controllers, hub and tests

## Testing
- `dotnet test` *(fails: GetDocument_ShouldReturnDocument_WhenDocumentExists, DeleteDocuments_ShouldReturnDeletedCount_WhenDocumentsAreDeletedSuccessfully)*

------
https://chatgpt.com/codex/tasks/task_e_687fbeb06aa4832eb074b2b541477d9b