### PR TITLE
Handle tenant names

### DIFF
--- a/IntelligenceHub.DAL/DbMappingHandler.cs
+++ b/IntelligenceHub.DAL/DbMappingHandler.cs
@@ -13,6 +13,25 @@ namespace IntelligenceHub.DAL
     /// </summary>
     public static class DbMappingHandler
     {
+        /// <summary>
+        /// Appends the tenant id to an entity name. If the name already
+        /// contains the tenant prefix it is returned unchanged.
+        /// </summary>
+        public static string AppendTenantToName(string name, Guid tenantId)
+        {
+            var prefix = $"{tenantId}_";
+            return name.StartsWith(prefix) ? name : prefix + name;
+        }
+
+        /// <summary>
+        /// Removes the tenant id prefix from an entity name if present.
+        /// </summary>
+        public static string RemoveTenantFromName(string name, Guid tenantId)
+        {
+            var prefix = $"{tenantId}_";
+            return name.StartsWith(prefix) ? name[prefix.Length..] : name;
+        }
+
         #region Profiles
 
         /// <summary>
@@ -25,7 +44,7 @@ namespace IntelligenceHub.DAL
             var profile = new Profile()
             {
                 Id = dbProfile.Id,
-                Name = dbProfile.Name,
+                Name = RemoveTenantFromName(dbProfile.Name, dbProfile.TenantId),
                 Model = dbProfile.Model,
                 Host = dbProfile.Host.ConvertToServiceHost(),
                 ImageHost = dbProfile.ImageHost?.ConvertToServiceHost(),
@@ -46,13 +65,13 @@ namespace IntelligenceHub.DAL
                     Id = pt.Tool.Id, 
                     Function = new Function() 
                     { 
-                        Name = pt.Tool.Name, 
+                        Name = RemoveTenantFromName(pt.Tool.Name, pt.Tool.TenantId),
                         Description = pt.Tool.Description, 
                         Parameters = new Parameters() 
                         { 
                             type = "object", 
                             required = pt.Tool.Required.ToStringArray(),  
-                            properties = pt.Tool.Properties.ToDictionary(p => p.Name, p => new Property() 
+                            properties = pt.Tool.Properties.ToDictionary(p => RemoveTenantFromName(p.Name, p.TenantId), p => new Property()
                             { 
                                 Id = p.Id, 
                                 type = p.Type, 
@@ -133,7 +152,7 @@ namespace IntelligenceHub.DAL
                 ExecutionBase64Key = dbTool.ExecutionBase64Key,
                 Function = new Function()
                 {
-                    Name = dbTool.Name,
+                    Name = RemoveTenantFromName(dbTool.Name, dbTool.TenantId),
                     Description = dbTool.Description
                 }
             };
@@ -147,7 +166,7 @@ namespace IntelligenceHub.DAL
                     type = property.Type,
                     description = property.Description,
                 };
-                tool.Function.Parameters.properties.Add(property.Name, convertedProp);
+                tool.Function.Parameters.properties.Add(RemoveTenantFromName(property.Name, property.TenantId), convertedProp);
                 tool.Function.Parameters.required = dbTool.Required.ToStringArray();
             }
             return tool;
@@ -282,7 +301,7 @@ namespace IntelligenceHub.DAL
         {
             return new IndexMetadata()
             {
-                Name = dbIndexData.Name,
+                Name = RemoveTenantFromName(dbIndexData.Name, dbIndexData.TenantId),
                 QueryType = dbIndexData.QueryType?.ConvertStringToQueryType() ?? QueryType.Simple,
                 GenerationHost = dbIndexData.GenerationHost.ConvertToServiceHost(),
                 RagHost = dbIndexData.RagHost.ConvertToRagHost(),

--- a/IntelligenceHub.DAL/Implementations/GenericRepository.cs
+++ b/IntelligenceHub.DAL/Implementations/GenericRepository.cs
@@ -59,6 +59,12 @@ namespace IntelligenceHub.DAL.Implementations
             if (entity is ITenantEntity tenantEntity && _tenantProvider.TenantId.HasValue)
             {
                 tenantEntity.TenantId = _tenantProvider.TenantId.Value;
+                var nameProp = entity.GetType().GetProperty("Name");
+                if (nameProp != null && nameProp.PropertyType == typeof(string))
+                {
+                    var current = nameProp.GetValue(entity) as string ?? string.Empty;
+                    nameProp.SetValue(entity, DbMappingHandler.AppendTenantToName(current, tenantEntity.TenantId));
+                }
             }
             await _dbSet.AddAsync(entity);
             await _context.SaveChangesAsync();
@@ -76,6 +82,12 @@ namespace IntelligenceHub.DAL.Implementations
             if (entity is ITenantEntity tenantEntity && _tenantProvider.TenantId.HasValue)
             {
                 tenantEntity.TenantId = _tenantProvider.TenantId.Value;
+                var nameProp = entity.GetType().GetProperty("Name");
+                if (nameProp != null && nameProp.PropertyType == typeof(string))
+                {
+                    var current = nameProp.GetValue(entity) as string ?? string.Empty;
+                    nameProp.SetValue(entity, DbMappingHandler.AppendTenantToName(current, tenantEntity.TenantId));
+                }
             }
             _dbSet.Attach(entity);
             _context.Entry(entity).State = EntityState.Modified;

--- a/IntelligenceHub.Tests.Unit/DAL/DbMappingHandlerTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/DbMappingHandlerTests.cs
@@ -16,10 +16,12 @@ namespace IntelligenceHub.Tests.Unit.DAL
         public void MapFromDbProfile_ShouldMapCorrectly()
         {
             // Arrange
+            var tenant = Guid.NewGuid();
             var dbProfile = new DbProfile
             {
                 Id = 1,
-                Name = "Test Profile",
+                TenantId = tenant,
+                Name = DbMappingHandler.AppendTenantToName("Test Profile", tenant),
                 Model = "Test Model",
                 Host = "Azure",
                 ImageHost = "Azure",
@@ -42,7 +44,7 @@ namespace IntelligenceHub.Tests.Unit.DAL
 
             // Assert
             Assert.Equal(dbProfile.Id, result.Id);
-            Assert.Equal(dbProfile.Name, result.Name);
+            Assert.Equal("Test Profile", result.Name);
             Assert.Equal(dbProfile.Model, result.Model);
             Assert.Equal(dbProfile.Host, result.Host.ToString());
             Assert.Equal(dbProfile.ImageHost, result.ImageHost.ToString());
@@ -105,10 +107,12 @@ namespace IntelligenceHub.Tests.Unit.DAL
         public void MapFromDbTool_ShouldMapCorrectly()
         {
             // Arrange
+            var tenant = Guid.NewGuid();
             var dbTool = new DbTool
             {
                 Id = 1,
-                Name = "Test Tool",
+                TenantId = tenant,
+                Name = DbMappingHandler.AppendTenantToName("Test Tool", tenant),
                 Description = "Test Description",
                 ExecutionUrl = "http://test.com",
                 ExecutionMethod = "POST",
@@ -118,8 +122,8 @@ namespace IntelligenceHub.Tests.Unit.DAL
 
             var dbProperties = new List<DbProperty>
             {
-                new DbProperty { Id = 1, Name = "Param1", Type = "string", Description = "Test Param 1" },
-                new DbProperty { Id = 2, Name = "Param2", Type = "int", Description = "Test Param 2" }
+                new DbProperty { Id = 1, TenantId = tenant, Name = DbMappingHandler.AppendTenantToName("Param1", tenant), Type = "string", Description = "Test Param 1" },
+                new DbProperty { Id = 2, TenantId = tenant, Name = DbMappingHandler.AppendTenantToName("Param2", tenant), Type = "int", Description = "Test Param 2" }
             };
 
             // Act
@@ -130,7 +134,7 @@ namespace IntelligenceHub.Tests.Unit.DAL
             Assert.Equal(dbTool.ExecutionUrl, result.ExecutionUrl);
             Assert.Equal(dbTool.ExecutionMethod, result.ExecutionMethod);
             Assert.Equal(dbTool.ExecutionBase64Key, result.ExecutionBase64Key);
-            Assert.Equal(dbTool.Name, result.Function.Name);
+            Assert.Equal("Test Tool", result.Function.Name);
             Assert.Equal(dbTool.Description, result.Function.Description);
             Assert.Equal(dbTool.Required.Split(','), result.Function.Parameters.required);
             Assert.Equal(dbProperties.Count, result.Function.Parameters.properties.Count);
@@ -306,9 +310,11 @@ namespace IntelligenceHub.Tests.Unit.DAL
         public void MapFromDbIndexMetadata_ShouldMapCorrectly()
         {
             // Arrange
+            var tenant = Guid.NewGuid();
             var dbIndexData = new DbIndexMetadata
             {
-                Name = "Test Name",
+                TenantId = tenant,
+                Name = DbMappingHandler.AppendTenantToName("Test Name", tenant),
                 QueryType = "Simple",
                 GenerationHost = AGIServiceHost.Azure.ToString(),
                 ChunkOverlap = 0.5,
@@ -334,7 +340,7 @@ namespace IntelligenceHub.Tests.Unit.DAL
             var result = DbMappingHandler.MapFromDbIndexMetadata(dbIndexData);
 
             // Assert
-            Assert.Equal(dbIndexData.Name, result.Name);
+            Assert.Equal("Test Name", result.Name);
             Assert.Equal(dbIndexData.QueryType, result.QueryType.ToString());
             Assert.Equal(dbIndexData.GenerationHost, result.GenerationHost.ToString());
             Assert.Equal(dbIndexData.ChunkOverlap, result.ChunkOverlap);

--- a/IntelligenceHub.Tests.Unit/DAL/GenericRepositoryTests.cs
+++ b/IntelligenceHub.Tests.Unit/DAL/GenericRepositoryTests.cs
@@ -1,4 +1,6 @@
-﻿using IntelligenceHub.DAL;
+﻿using System;
+using System.Linq;
+using IntelligenceHub.DAL;
 using IntelligenceHub.DAL.Implementations;
 using IntelligenceHub.DAL.Models;
 using IntelligenceHub.DAL.Tenant;
@@ -58,6 +60,19 @@ namespace IntelligenceHub.Tests.Unit.DAL
 
             var page2 = await repo.GetAllAsync(2, 2);
             Assert.Equal(new[] { "2", "3" }, page2.Select(m => m.Content));
+        }
+
+        [Fact]
+        public async Task AddAsync_AppendsTenantToName()
+        {
+            await using var context = CreateContext();
+            _tenantProvider.TenantId = Guid.NewGuid();
+            var repo = new GenericRepository<DbProfile>(context, _tenantProvider);
+
+            var profile = new DbProfile { Name = "MyProfile" };
+            var added = await repo.AddAsync(profile);
+
+            Assert.StartsWith(_tenantProvider.TenantId.ToString(), added.Name);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add helper methods for tenant-prefixed names
- strip tenant prefixes when mapping from database
- prefix names in GenericRepository when saving
- update mapping and repository unit tests

## Testing
- `dotnet test IntelligenceHub.sln` *(fails: DbMappingHandler does not contain a definition for AppendTenantToName)*

------
https://chatgpt.com/codex/tasks/task_e_687fe7cc2090832eb46492af91568ca7