### PR TITLE
Fix quota concurrency and validation order

### DIFF
--- a/IntelligenceHub.Controllers/CompletionController.cs
+++ b/IntelligenceHub.Controllers/CompletionController.cs
@@ -61,12 +61,12 @@ namespace IntelligenceHub.Controllers
             {
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
-                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
-                if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 name = name?.Replace("{name}", string.Empty); // come up with a more long term fix for this
-                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = name; 
+                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = name;
                 var errorMessage = _validationLogic.ValidateChatRequest(completionRequest);
                 if (errorMessage is not null) return BadRequest(errorMessage);
+                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
+                if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 var response = await _completionLogic.ProcessCompletion(completionRequest);
                 if (response.IsSuccess) return Ok(response.Data);
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -100,12 +100,12 @@ namespace IntelligenceHub.Controllers
             {
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
-                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
-                if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 name = name?.Replace("{name}", string.Empty); // come up with a more long term fix for this
                 if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = name;
                 var errorMessage = _validationLogic.ValidateChatRequest(completionRequest);
                 if (errorMessage is not null) return BadRequest(errorMessage);
+                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
+                if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 var response = _completionLogic.StreamCompletion(completionRequest);
 
                 // set headers to return SSE

--- a/IntelligenceHub.DAL/Interfaces/IUserRepository.cs
+++ b/IntelligenceHub.DAL/Interfaces/IUserRepository.cs
@@ -1,4 +1,5 @@
 using IntelligenceHub.DAL.Models;
+using System;
 
 namespace IntelligenceHub.DAL.Interfaces
 {
@@ -25,5 +26,14 @@ namespace IntelligenceHub.DAL.Interfaces
         /// Updates a user entity.
         /// </summary>
         Task<DbUser> UpdateAsync(DbUser user);
+
+        /// <summary>
+        /// Atomically increments the monthly request count if the quota is not exceeded.
+        /// </summary>
+        /// <param name="userId">The identifier of the user.</param>
+        /// <param name="now">The current timestamp used to determine the month.</param>
+        /// <param name="limit">The allowed monthly request quota.</param>
+        /// <returns><c>true</c> if the count was incremented; otherwise, <c>false</c>.</returns>
+        Task<bool> TryIncrementMonthlyRequestAsync(int userId, DateTime now, int limit);
     }
 }

--- a/IntelligenceHub.Hubs/ChatHub.cs
+++ b/IntelligenceHub.Hubs/ChatHub.cs
@@ -64,17 +64,17 @@ namespace IntelligenceHub.Hubs
                 _tenantProvider.TenantId = user.TenantId;
                 _tenantProvider.User = user;
 
-                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(user);
-                if (!usageResult.IsSuccess)
-                {
-                    await Clients.Caller.SendAsync("broadcastMessage", $"Response Status: {APIResponseStatusCodes.TooManyRequests}. Error message: {usageResult.ErrorMessage}");
-                    return;
-                }
-
                 var errorMessage = _validationLogic.ValidateChatRequest(completionRequest);
                 if (!string.IsNullOrEmpty(errorMessage))
                 {
                     await Clients.Caller.SendAsync("broadcastMessage", errorMessage);
+                    return;
+                }
+
+                var usageResult = await _usageService.ValidateAndIncrementUsageAsync(user);
+                if (!usageResult.IsSuccess)
+                {
+                    await Clients.Caller.SendAsync("broadcastMessage", $"Response Status: {APIResponseStatusCodes.TooManyRequests}. Error message: {usageResult.ErrorMessage}");
                     return;
                 }
 

--- a/IntelligenceHub.Tests.Unit/Controllers/CompletionControllerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Controllers/CompletionControllerTests.cs
@@ -97,6 +97,7 @@ namespace IntelligenceHub.Tests.Unit.Controllers
             var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
             Assert.Equal(errorMessage, badRequestResult.Value);
+            _mockUsageService.Verify(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>()), Times.Never);
         }
 
         [Fact]
@@ -231,6 +232,7 @@ namespace IntelligenceHub.Tests.Unit.Controllers
             var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
             Assert.Equal(errorMessage, badRequestResult.Value);
+            _mockUsageService.Verify(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>()), Times.Never);
         }
 
         [Fact]

--- a/IntelligenceHub.Tests.Unit/Hubs/ChatHubTests.cs
+++ b/IntelligenceHub.Tests.Unit/Hubs/ChatHubTests.cs
@@ -75,6 +75,7 @@ namespace IntelligenceHub.Tests.Unit.Hubs
 
             clientProxy.Verify(p => p.SendCoreAsync("broadcastMessage", It.Is<object[]>(o => (string)o[0] == error), default), Times.Once);
             completionMock.Verify(c => c.StreamCompletion(It.IsAny<CompletionRequest>()), Times.Never);
+            usageMock.Verify(u => u.ValidateAndIncrementUsageAsync(It.IsAny<DbUser>()), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- check request payload before counting usage
- atomically increment monthly usage in `UserRepository`
- update `UsageService` to use new repository method
- adjust unit tests for new behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe912469c832ea350e8d7025a072e