### PR TITLE
Append tenant id to key objects

### DIFF
--- a/IntelligenceHub.Controllers/CompletionController.cs
+++ b/IntelligenceHub.Controllers/CompletionController.cs
@@ -64,7 +64,8 @@ namespace IntelligenceHub.Controllers
                 var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
                 if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 name = name?.Replace("{name}", string.Empty); // come up with a more long term fix for this
-                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = name; 
+                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = AppendTenant(name);
+                else completionRequest.ProfileOptions.Name = AppendTenant(completionRequest.ProfileOptions.Name);
                 var errorMessage = _validationLogic.ValidateChatRequest(completionRequest);
                 if (errorMessage is not null) return BadRequest(errorMessage);
                 var response = await _completionLogic.ProcessCompletion(completionRequest);
@@ -103,7 +104,8 @@ namespace IntelligenceHub.Controllers
                 var usageResult = await _usageService.ValidateAndIncrementUsageAsync(_tenantProvider.User!);
                 if (!usageResult.IsSuccess) return StatusCode(StatusCodes.Status429TooManyRequests, usageResult.ErrorMessage);
                 name = name?.Replace("{name}", string.Empty); // come up with a more long term fix for this
-                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = name;
+                if (!string.IsNullOrEmpty(name)) completionRequest.ProfileOptions.Name = AppendTenant(name);
+                else completionRequest.ProfileOptions.Name = AppendTenant(completionRequest.ProfileOptions.Name);
                 var errorMessage = _validationLogic.ValidateChatRequest(completionRequest);
                 if (errorMessage is not null) return BadRequest(errorMessage);
                 var response = _completionLogic.StreamCompletion(completionRequest);

--- a/IntelligenceHub.Controllers/ProfileController.cs
+++ b/IntelligenceHub.Controllers/ProfileController.cs
@@ -48,6 +48,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrWhiteSpace(name)) return BadRequest("Invalid route data. Please check your input.");
+                name = AppendTenant(name);
                 var response = await _profileLogic.GetProfile(name);
                 if (!response.IsSuccess) return NotFound(response.ErrorMessage);
 
@@ -106,6 +107,7 @@ namespace IntelligenceHub.Controllers
             {
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
+                profileDto.Name = AppendTenant(profileDto.Name);
                 var updateResponse = await _profileLogic.CreateOrUpdateProfile(profileDto);
                 if (!updateResponse.IsSuccess)
                 {
@@ -144,6 +146,8 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest($"Invalid request. Please check the route parameter for the profile name: '{name}'.");
                 if (tools is null || tools.Count < 1) return BadRequest($"Invalid request. The 'Tools' property cannot be null or empty: '{tools}'.");
+                name = AppendTenant(name);
+                tools = tools.Select(AppendTenant).ToList();
                 var response = await _profileLogic.AddProfileToTools(name, tools);
                 if (response.IsSuccess)
                 {
@@ -179,6 +183,8 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest($"Invalid request. Please check the route parameter for the profile name: '{name}'.");
                 if (tools is null || tools.Count < 1) return BadRequest($"Invalid request. The 'Tools' property cannot be null or empty: '{tools}'.");
+                name = AppendTenant(name);
+                tools = tools.Select(AppendTenant).ToList();
                 var response = await _profileLogic.DeleteProfileAssociations(name, tools);
 
                 if (response.IsSuccess) return Ok(response.Data);
@@ -209,6 +215,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrWhiteSpace(name)) return BadRequest($"Invalid request. Please check the route parameter for the profile name: {name}.");
+                name = AppendTenant(name);
                 var response = await _profileLogic.DeleteProfile(name);
 
                 if (!response.IsSuccess)

--- a/IntelligenceHub.Controllers/RagController.cs
+++ b/IntelligenceHub.Controllers/RagController.cs
@@ -51,6 +51,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'");
+                index = AppendTenant(index);
                 var response = await _ragLogic.GetRagIndex(index);
                 if (response.IsSuccess) return Ok(response.Data);
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -106,6 +107,7 @@ namespace IntelligenceHub.Controllers
                 if (indexDefinition is null) return BadRequest("The request body is malformed.");
                 if (!_featureFlags.UseAzureAISearch && indexDefinition.RagHost == RagServiceHost.Azure)
                     return BadRequest("Azure is not a supported RAG host for your pricing tier.");
+                indexDefinition.Name = AppendTenant(indexDefinition.Name);
                 var response = await _ragLogic.CreateIndex(indexDefinition);
                 if (response.IsSuccess) return Ok(indexDefinition);
                 else if (response.StatusCode == APIResponseStatusCodes.BadRequest) return BadRequest(response.ErrorMessage);
@@ -138,6 +140,7 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (indexDefinition is null) return BadRequest("The request body is malformed.");
                 if (!_featureFlags.UseAzureAISearch && indexDefinition.RagHost == RagServiceHost.Azure) return BadRequest("Azure is not a supported RAG host for your pricing tier.");
+                indexDefinition.Name = AppendTenant(indexDefinition.Name);
                 var response = await _ragLogic.ConfigureIndex(indexDefinition);
                 if (response.IsSuccess) return Ok(indexDefinition);
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -170,6 +173,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(query)) return BadRequest("The required route parameter, 'query', is null or empty.");
+                index = AppendTenant(index);
                 var response = await _ragLogic.QueryIndex(index, query);
                 if (response.IsSuccess) return Ok(response.Data);
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -200,6 +204,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'");
+                index = AppendTenant(index);
                 var response = await _ragLogic.RunIndexUpdate(index);
                 if (response.IsSuccess) return NoContent();
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -231,6 +236,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'");
+                index = AppendTenant(index);
                 var response = await _ragLogic.DeleteIndex(index);
                 if (response.IsSuccess) return NoContent();
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -265,6 +271,7 @@ namespace IntelligenceHub.Controllers
                 if (page < 1) return BadRequest("Page must be 1 or greater");
                 if (count < 1) return BadRequest("Count must be 1 or greater");
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'");
+                index = AppendTenant(index);
 
                 var response = await _ragLogic.GetAllDocuments(index, count, page);
                 if (response.IsSuccess) return Ok(response.Data ?? new List<IndexDocument>());
@@ -295,6 +302,7 @@ namespace IntelligenceHub.Controllers
             {
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
+                index = AppendTenant(index);
                 var response = await _ragLogic.GetDocument(index, document);
                 if (response.IsSuccess) return Ok(response.Data);
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
@@ -327,6 +335,7 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (documentUpsertRequest == null || documentUpsertRequest.Documents.Count < 1) return BadRequest("The request body is malformed or contains less than 1 document.");
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'.");
+                index = AppendTenant(index);
                 foreach (var doc in documentUpsertRequest.Documents) if (doc.Title.Contains('/') || doc.Title.Contains('\\')) return BadRequest($"Document titles cannot contain slashes. Document: {doc.Title}");
                 var response = await _ragLogic.UpsertDocuments(index, documentUpsertRequest);
                 if (response.IsSuccess) return Ok(documentUpsertRequest);
@@ -361,6 +370,7 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 var documents = commaDelimitedDocNames.ToStringArray();
                 if (string.IsNullOrEmpty(index)) return BadRequest($"Invalid index name: '{index}'.");
+                index = AppendTenant(index);
                 if (documents.Length < 1) return BadRequest("No document names were provided in the request route.");
                 var response = await _ragLogic.DeleteDocuments(index, documents);
                 if (response.IsSuccess) return Ok(response.Data);

--- a/IntelligenceHub.Controllers/TenantControllerBase.cs
+++ b/IntelligenceHub.Controllers/TenantControllerBase.cs
@@ -41,5 +41,17 @@ namespace IntelligenceHub.Controllers
 
             return APIResponseWrapper<Guid>.Success(user.TenantId);
         }
+
+        /// <summary>
+        /// Appends the current tenant identifier to a name if it is not already present.
+        /// </summary>
+        /// <param name="name">The base name.</param>
+        /// <returns>The name with the tenant identifier appended.</returns>
+        protected string AppendTenant(string name)
+        {
+            var tenant = _tenantProvider.TenantId?.ToString();
+            if (string.IsNullOrEmpty(tenant)) return name;
+            return name.EndsWith("_" + tenant) ? name : $"{name}_{tenant}";
+        }
     }
 }

--- a/IntelligenceHub.Controllers/ToolController.cs
+++ b/IntelligenceHub.Controllers/ToolController.cs
@@ -48,6 +48,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest("Invalid request. Please check the route parameter for the profile name.");
+                name = AppendTenant(name);
                 var response = await _profileLogic.GetTool(name);
 
                 if (response.IsSuccess) return Ok(response.Data);
@@ -106,6 +107,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest("Invalid request. Please check the route parameter for the profile name.");
+                name = AppendTenant(name);
                 var response = await _profileLogic.GetToolProfileAssociations(name);
                 if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);
                 return Ok(response.Data ?? new List<string>());
@@ -133,6 +135,7 @@ namespace IntelligenceHub.Controllers
             {
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
+                foreach (var tool in toolList) tool.Function.Name = AppendTenant(tool.Function.Name);
                 var response = await _profileLogic.CreateOrUpdateTools(toolList);
                 if (!response.IsSuccess) return BadRequest(response.ErrorMessage);
                 else return Ok(toolList);
@@ -164,6 +167,8 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest("Invalid request. Please check the route parameter for the profile name.");
                 if (profiles == null || profiles.Count < 1) return BadRequest("Invalid request. 'Profiles' property cannot be null or empty.");
+                name = AppendTenant(name);
+                profiles = profiles.Select(AppendTenant).ToList();
                 var response = await _profileLogic.AddToolToProfiles(name, profiles);
                 if (response.IsSuccess)
                 {
@@ -201,6 +206,8 @@ namespace IntelligenceHub.Controllers
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest("Invalid request. Please check the route parameter for the profile name.");
                 if (profiles == null || profiles.Count < 1) return BadRequest("Invalid request. 'Profiles' property cannot be null or empty.");
+                name = AppendTenant(name);
+                profiles = profiles.Select(AppendTenant).ToList();
                 var response = await _profileLogic.DeleteToolAssociations(name, profiles);
                 if (response.IsSuccess) return Ok(response.Data);
                 else return NotFound(response.ErrorMessage);
@@ -230,6 +237,7 @@ namespace IntelligenceHub.Controllers
                 var tenantResult = await SetUserTenantContextAsync();
                 if (!tenantResult.IsSuccess) return StatusCode(StatusCodes.Status500InternalServerError, tenantResult.ErrorMessage);
                 if (string.IsNullOrEmpty(name)) return BadRequest("Invalid request. Please check the route parameter for the profile name.");
+                name = AppendTenant(name);
                 var response = await _profileLogic.DeleteTool(name);
                 if (response.IsSuccess) return NoContent();
                 else if (response.StatusCode == APIResponseStatusCodes.NotFound) return NotFound(response.ErrorMessage);


### PR DESCRIPTION
## Summary
- helper `AppendTenant` on `TenantControllerBase`
- use `AppendTenant` when working with names in `ProfileController`
- use `AppendTenant` for tool endpoints in `ToolController`
- use `AppendTenant` for RAG index names in `RagController`
- apply tenant name logic in `CompletionController`

## Testing
- `dotnet test` *(fails: Assert.IsType Failure)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc6c6a6c832ea88fe8654ba39604