### PR TITLE
Improve tool execution validation

### DIFF
--- a/IntelligenceHub.Business/Handlers/ValidationHandler.cs
+++ b/IntelligenceHub.Business/Handlers/ValidationHandler.cs
@@ -197,7 +197,39 @@ namespace IntelligenceHub.Business.Handlers
             {
                 foreach (var str in tool.Function.Parameters.required) if (!tool.Function.Parameters.properties.ContainsKey(str)) return $"Required property {str} does not exist in the tool {tool.Function.Name}'s properties list.";
             }
-            if (!string.IsNullOrEmpty(tool.ExecutionUrl) && !tool.ExecutionUrl.StartsWith("https://") && !tool.ExecutionUrl.StartsWith("http://")) return $"Please provide a valid execution url for the tool {tool.Function.Name}. Supplied url: '{tool.ExecutionUrl}'.";
+            if (!string.IsNullOrEmpty(tool.ExecutionUrl))
+            {
+                if (!Uri.TryCreate(tool.ExecutionUrl, UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                {
+                    return $"Please provide a valid execution url for the tool {tool.Function.Name}. Supplied url: '{tool.ExecutionUrl}'.";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(tool.ExecutionMethod))
+            {
+                var validMethods = new[] { "GET", "POST", "PUT", "PATCH", "DELETE" };
+                if (!validMethods.Contains(tool.ExecutionMethod.ToUpperInvariant()))
+                {
+                    return $"Please provide a valid execution method for the tool {tool.Function.Name}. Supplied method: '{tool.ExecutionMethod}'. Valid values are {string.Join(", ", validMethods)}.";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(tool.ExecutionBase64Key))
+            {
+                try
+                {
+                    var decoded = Convert.FromBase64String(tool.ExecutionBase64Key);
+                    if (decoded.Length == 0)
+                    {
+                        return $"Please provide a valid base64 encoded execution key for the tool {tool.Function.Name}. Supplied key: '{tool.ExecutionBase64Key}'.";
+                    }
+                }
+                catch (FormatException)
+                {
+                    return $"Please provide a valid base64 encoded execution key for the tool {tool.Function.Name}. Supplied key: '{tool.ExecutionBase64Key}'.";
+                }
+            }
 
             if (tool.Function.Parameters.properties != null && tool.Function.Parameters.properties.Count > 0)
             {

--- a/IntelligenceHub.Tests.Unit/Business/ValidationHandlerTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/ValidationHandlerTests.cs
@@ -280,7 +280,7 @@ namespace IntelligenceHub.Tests.Unit.Business
                     }
                 },
                 ExecutionUrl = "http://example.com",
-                ExecutionBase64Key = "key",
+                ExecutionBase64Key = "a2V5",
                 ExecutionMethod = "GET"
             };
 
@@ -289,6 +289,90 @@ namespace IntelligenceHub.Tests.Unit.Business
 
             // Assert
             Assert.Null(result);
+        }
+
+        [Fact]
+        public void ValidateTool_WithInvalidExecutionUrl_ReturnsError()
+        {
+            // Arrange - Tool with invalid execution URL.
+            var tool = new IntelligenceHub.API.DTOs.Tools.Tool
+            {
+                Function = new IntelligenceHub.API.DTOs.Tools.Function
+                {
+                    Name = "TestTool",
+                    Description = "A test tool",
+                    Parameters = new IntelligenceHub.API.DTOs.Tools.Parameters
+                    {
+                        required = new string[] { },
+                        properties = new Dictionary<string, IntelligenceHub.API.DTOs.Tools.Property>()
+                    }
+                },
+                ExecutionUrl = "invalid-url",
+                ExecutionMethod = "GET",
+                ExecutionBase64Key = "a2V5"
+            };
+
+            // Act
+            var result = _handler.ValidateTool(tool);
+
+            // Assert
+            Assert.Equal("Please provide a valid execution url for the tool TestTool. Supplied url: 'invalid-url'.", result);
+        }
+
+        [Fact]
+        public void ValidateTool_WithInvalidExecutionMethod_ReturnsError()
+        {
+            // Arrange - Tool with invalid execution method.
+            var tool = new IntelligenceHub.API.DTOs.Tools.Tool
+            {
+                Function = new IntelligenceHub.API.DTOs.Tools.Function
+                {
+                    Name = "TestTool",
+                    Description = "A test tool",
+                    Parameters = new IntelligenceHub.API.DTOs.Tools.Parameters
+                    {
+                        required = new string[] { },
+                        properties = new Dictionary<string, IntelligenceHub.API.DTOs.Tools.Property>()
+                    }
+                },
+                ExecutionUrl = "http://example.com",
+                ExecutionMethod = "INVALID",
+                ExecutionBase64Key = "a2V5"
+            };
+
+            // Act
+            var result = _handler.ValidateTool(tool);
+
+            // Assert
+            Assert.Equal("Please provide a valid execution method for the tool TestTool. Supplied method: 'INVALID'. Valid values are GET, POST, PUT, PATCH, DELETE.", result);
+        }
+
+        [Fact]
+        public void ValidateTool_WithInvalidExecutionBase64Key_ReturnsError()
+        {
+            // Arrange - Tool with invalid base64 execution key.
+            var tool = new IntelligenceHub.API.DTOs.Tools.Tool
+            {
+                Function = new IntelligenceHub.API.DTOs.Tools.Function
+                {
+                    Name = "TestTool",
+                    Description = "A test tool",
+                    Parameters = new IntelligenceHub.API.DTOs.Tools.Parameters
+                    {
+                        required = new string[] { },
+                        properties = new Dictionary<string, IntelligenceHub.API.DTOs.Tools.Property>()
+                    }
+                },
+                ExecutionUrl = "http://example.com",
+                ExecutionMethod = "GET",
+                ExecutionBase64Key = "not-base64"
+            };
+
+            // Act
+            var result = _handler.ValidateTool(tool);
+
+            // Assert
+            Assert.Equal("Please provide a valid base64 encoded execution key for the tool TestTool. Supplied key: 'not-base64'.", result);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- validate tool execution URL with Uri parsing
- ensure HTTP method is within a known set
- verify execution key is valid base64
- add tests for execution validation cases

## Testing
- `dotnet test`
- `dotnet test IntelligenceHub.Tests.Unit/IntelligenceHub.Tests.Unit.csproj --filter FullyQualifiedName~ValidationHandlerTests`


------
https://chatgpt.com/codex/tasks/task_e_68916bbf08c0832ebad27cf0c332d7bb