### PR TITLE
Sanitize RAG document strings before persistence

### DIFF
--- a/IntelligenceHub.Business/Implementations/RagLogic.cs
+++ b/IntelligenceHub.Business/Implementations/RagLogic.cs
@@ -440,6 +440,12 @@ namespace IntelligenceHub.Business.Implementations
                 if (indexData.GenerateTopic) document.Topic = await GenerateDocumentMetadata("a topic", document, indexData.GenerationHost.ConvertToServiceHost());
                 if (indexData.GenerateKeywords) document.Keywords = await GenerateDocumentMetadata("a comma separated list of keywords", document, indexData.GenerationHost.ConvertToServiceHost());
 
+                document.Title = document.Title.CleanRagDbString() ?? string.Empty;
+                document.Content = document.Content.CleanRagDbString() ?? string.Empty;
+                document.Topic = document.Topic.CleanRagDbString();
+                document.Keywords = document.Keywords.CleanRagDbString();
+                document.Source = document.Source.CleanRagDbString() ?? string.Empty;
+
                 var newDbDocument = DbMappingHandler.MapToDbIndexDocument(document);
 
                 var existingDoc = await _ragRepository.GetDocumentAsync(indexData.Name, document.Title);

--- a/IntelligenceHub.Common/Extensions/ExtensionMethods.cs
+++ b/IntelligenceHub.Common/Extensions/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿using OpenAI.Chat;
 using System.Text;
+using System.Text.RegularExpressions;
 using static IntelligenceHub.Common.GlobalVariables;
 
 namespace IntelligenceHub.Common.Extensions
@@ -168,6 +169,21 @@ namespace IntelligenceHub.Common.Extensions
             if (index <= 0) return name;
             var suffix = name[(index + 1)..];
             return Guid.TryParse(suffix, out _) ? name[..index] : name;
+        }
+
+        /// <summary>
+        /// Normalizes a string for RAG database storage by collapsing whitespace
+        /// and removing unsupported control characters.
+        /// </summary>
+        /// <param name="input">The string to clean.</param>
+        /// <returns>The cleaned string, or null if the input was null.</returns>
+        public static string? CleanRagDbString(this string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return input?.Trim();
+
+            var cleaned = Regex.Replace(input, @"\s+", " ");
+            cleaned = Regex.Replace(cleaned, "[\u0000-\u001F\u007F-\u009F]", "");
+            return cleaned.Trim();
         }
     }
 }

--- a/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
+++ b/IntelligenceHub.Tests.Unit/Business/RagLogicTests.cs
@@ -699,6 +699,49 @@ namespace IntelligenceHub.Tests.Unit.Business
         }
 
         [Fact]
+        public async Task UpsertDocuments_ShouldCleanStringsBeforeUpsert()
+        {
+            // Arrange
+            var indexName = "testIndex";
+            var fullName = $"{indexName}_{_tenantProvider.Object.TenantId}";
+            var dbIndexMetadata = new DbIndexMetadata { Name = fullName, GenerationHost = AGIServiceHost.Azure.ToString() };
+
+            var document = new IndexDocument
+            {
+                Title = "  Test" + '\t' + "Title " + '\u0000',
+                Content = "  Test" + "\r\n" + "Content " + '\u0001',
+                Topic = " Test Topic " + '\u0002',
+                Keywords = "  kw1, kw2 " + '\u0003',
+                Source = "\tSource" + '\u0004'
+            };
+
+            var upsertRequest = new RagUpsertRequest { Documents = new List<IndexDocument> { document } };
+
+            _mockValidationHandler.Setup(repo => repo.IsValidIndexName(indexName)).Returns(true);
+            _mockValidationHandler.Setup(repo => repo.IsValidRagUpsertRequest(upsertRequest)).Returns(string.Empty);
+            _mockMetaRepository.Setup(repo => repo.GetByNameAsync(fullName)).ReturnsAsync(dbIndexMetadata);
+            _mockRagRepository.Setup(repo => repo.GetDocumentAsync(fullName, "Test Title")).ReturnsAsync((DbIndexDocument?)null);
+
+            DbIndexDocument? savedDoc = null;
+            _mockRagRepository
+                .Setup(repo => repo.AddAsync(It.IsAny<DbIndexDocument>(), fullName))
+                .Callback<DbIndexDocument, string>((doc, _) => savedDoc = doc)
+                .ReturnsAsync(new DbIndexDocument());
+
+            // Act
+            var result = await _ragLogic.UpsertDocuments(indexName, upsertRequest);
+
+            // Assert
+            Assert.True(result.Data);
+            Assert.NotNull(savedDoc);
+            Assert.Equal("Test Title", savedDoc!.Title);
+            Assert.Equal("Test Content", savedDoc.Content);
+            Assert.Equal("Test Topic", savedDoc.Topic);
+            Assert.Equal("kw1, kw2", savedDoc.Keywords);
+            Assert.Equal("Source", savedDoc.Source);
+        }
+
+        [Fact]
         public async Task GetDocument_ShouldReturnDocument_WhenDocumentExists()
         {
             // Arrange


### PR DESCRIPTION
## Summary
- add helper to trim whitespace and strip control characters for RAG DB compatibility
- clean document fields during RAG ingestion before writing to SQL
- cover string sanitation with a unit test

## Testing
- `dotnet test` *(fails: 102 failed, 194 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68916a4c8bfc832ea2779f857b8309e5